### PR TITLE
Improved Symbol Handling

### DIFF
--- a/src/b2/BeebWindow.cpp
+++ b/src/b2/BeebWindow.cpp
@@ -2472,6 +2472,10 @@ void BeebWindow::DoDebugMenu() {
             if (ImGui::MenuItem("Load Symbols...")) {
                 m_show_enhanced_symbol_window = true;
             }
+            if (ImGui::MenuItem("Reload All Symbols")) {
+                m_symbol_table.ReloadAllGroups();
+                m_msg.i.f("All symbol files have been reloaded from disk.\n");
+            }
             m_cst.DoMenuItem(g_popups[BeebWindowPopupType_SymbolGroupManagement].command);
 
             ImGui::Separator();
@@ -4707,6 +4711,13 @@ void BeebWindow::DoGroupManagementWindowContent() {
         if (ImGui::Button("Close")) {
             const uint64_t mask = (uint64_t)1 << BeebWindowPopupType_SymbolGroupManagement;
             m_settings.popups &= ~mask;
+        }
+
+        ImGui::SameLine();
+
+        if (ImGui::Button("Reload All")) {
+            m_symbol_table.ReloadAllGroups();
+            m_msg.i.f("All symbol files have been reloaded from disk.\n");
         }
 
         ImGui::SameLine();

--- a/src/b2/BeebWindow.cpp
+++ b/src/b2/BeebWindow.cpp
@@ -2,6 +2,8 @@
 #include "nlohmann_json_wrapper.h"
 #include <shared/system_specific.h>
 #include "BeebWindow.h"
+#include "symbol_ui_constants.h"
+#include "memory_contexts.h"
 #include <beeb/OutputData.h>
 #include "Remapper.h"
 #include <beeb/conf.h>
@@ -242,6 +244,7 @@ static bool InitialiseTogglePopupCommands() {
     InitialiseTogglePopupCommand(BeebWindowPopupType_HardDiskDebug, "toggle_hard_disk_debug", "Hard Disk Debug", &CreateHardDiskDebugWindow);
     InitialiseTogglePopupCommand(BeebWindowPopupType_SCSIDebug, "toggle_scsi_debug", "SCSI Debug", &CreateSCSIDebugWindow);
     InitialiseTogglePopupCommand(BeebWindowPopupType_SerialDebug, "toggle_serial_debug", "Serial Debug", &CreateSerialDebugWindow);
+    InitialiseTogglePopupCommand(BeebWindowPopupType_SymbolGroupManagement, "toggle_symbol_group_management", "Symbol Group Management", &CreateSymbolGroupManagementWindow);
     return true;
 }
 
@@ -691,6 +694,19 @@ BeebWindow::BeebWindow(BeebWindowInitArguments init_arguments)
         m_settings = init_arguments.settings;
     } else {
         m_settings = BeebWindows::defaults;
+    }
+
+    // Load symbol table from persistent data if available
+    if (!m_settings.symbol_table_data.empty()) {
+        try {
+            if (m_symbol_table.LoadFromJSON(m_settings.symbol_table_data)) {
+                LOGF(SYMBOLS, "Restored symbol table persistence data with %zu groups\n", m_symbol_table.GetAllGroups().size());
+            } else {
+                LOGF(SYMBOLS, "WARNING: Failed to load symbol table persistence data - JSON was valid but load failed\n");
+            }
+        } catch (const std::exception &e) {
+            LOGF(SYMBOLS, "ERROR: Failed to load symbol table persistence data: %s\n", e.what());
+        }
     }
 
     m_beeb_thread->SetBBCVolume(m_settings.bbc_volume, m_settings.bbc_mute);
@@ -1194,6 +1210,11 @@ bool BeebWindow::DoImGui(uint64_t ticks) {
         beeb_got_imgui_focus = this->DoBeebDisplayUI();
 
         this->DoPopupUI(ticks, output_width, output_height);
+    }
+
+    // Independent symbol loading window (outside any menu context)
+    if (m_show_enhanced_symbol_window) {
+        this->DoSymbolLoadingWindow();
     }
 
 #if ENABLE_IMGUI_DEMO
@@ -2448,18 +2469,129 @@ void BeebWindow::DoDebugMenu() {
             if (ImGui::MenuItem("Clear Symbols")) {
                 m_symbol_table.Clear();
             }
-            if (ImGui::MenuItem("Load Symbols File...")) {
-                this->OpenSymbolsFileDialog();
+            if (ImGui::MenuItem("Load Symbols...")) {
+                m_show_enhanced_symbol_window = true;
             }
+            m_cst.DoMenuItem(g_popups[BeebWindowPopupType_SymbolGroupManagement].command);
 
             ImGui::Separator();
 
-            // Show loaded symbols count
-            size_t count = m_symbol_table.GetSymbolCount();
-            if (count > 0) {
-                ImGui::Text("Loaded symbols: %zu", count);
+            // Show loaded groups and symbols (grouped by name for bulk operations)
+            const auto &groups = m_symbol_table.GetAllGroups();
+            if (!groups.empty()) {
+                ImGui::Text("Loaded symbol groups:");
+
+                // Group entries by name for consolidated display
+                std::map<std::string, std::vector<size_t>> groups_by_name;
+                for (size_t i = 0; i < groups.size(); ++i) {
+                    groups_by_name[groups[i].name].push_back(i);
+                }
+
+                // Show one checkbox per unique group name
+                for (const auto &[group_name, indices] : groups_by_name) {
+                    // Determine combined state for this group name
+                    size_t enabled_count = 0;
+                    size_t total_count = indices.size();
+                    std::vector<std::string> file_names;
+
+                    for (size_t idx : indices) {
+                        if (groups[idx].enabled) {
+                            enabled_count++;
+                        }
+                        // Extract filename for tooltip
+                        std::string file_path = groups[idx].file_path;
+                        size_t last_slash = file_path.find_last_of("/\\");
+                        if (last_slash != std::string::npos) {
+                            file_names.push_back(file_path.substr(last_slash + 1));
+                        } else {
+                            file_names.push_back(file_path);
+                        }
+                    }
+
+                    // Determine checkbox state
+                    bool all_enabled = (enabled_count == total_count);
+                    bool any_enabled = (enabled_count > 0);
+                    bool mixed_state = any_enabled && !all_enabled;
+
+                    // Show checkbox with appropriate state (including tristate for mixed)
+                    bool current_state = all_enabled;
+
+                    // Use ImGui's built-in tristate checkbox for mixed states
+                    if (mixed_state) {
+                        ImGui::PushItemFlag(ImGuiItemFlags_MixedValue, true);
+                    }
+
+                    if (ImGui::Checkbox(group_name.c_str(), &current_state)) {
+                        // Handle checkbox interaction
+                        if (mixed_state) {
+                            // Mixed state clicked: enable all
+                            for (size_t idx : indices) {
+                                m_symbol_table.EnableGroup(idx, true);
+                            }
+                        } else {
+                            // Normal toggle: affects all entries with this name
+                            for (size_t idx : indices) {
+                                m_symbol_table.EnableGroup(idx, current_state);
+                            }
+                        }
+                    }
+
+                    if (mixed_state) {
+                        ImGui::PopItemFlag();
+                    }
+
+                    // Enhanced tooltip showing all files in this group name
+                    if (ImGui::IsItemHovered()) {
+                        ImGui::BeginTooltip();
+                        if (total_count == 1) {
+                            // Single file
+                            ImGui::Text("File: %s", file_names[0].c_str());
+                            if (!groups[indices[0]].memory_contexts.empty()) {
+                                ImGui::Text("Memory contexts (%zu total):", groups[indices[0]].memory_contexts.size());
+
+                                // Display contexts in groups per line
+                                std::string line_text;
+                                size_t count = 0;
+                                for (char c : groups[indices[0]].memory_contexts) {
+                                    if (count > 0 && count % SymbolUI::CONTEXTS_PER_TOOLTIP_LINE == 0) {
+                                        // Show completed line and start new one
+                                        ImGui::Text("  %s", line_text.c_str());
+                                        line_text.clear();
+                                    }
+                                    if (!line_text.empty())
+                                        line_text += ", ";
+                                    line_text += "'";
+                                    line_text += c;
+                                    line_text += "'";
+                                    count++;
+                                }
+                                // Show final line if not empty
+                                if (!line_text.empty()) {
+                                    ImGui::Text("  %s", line_text.c_str());
+                                }
+                            }
+                        } else {
+                            // Multiple files
+                            ImGui::Text("%s (%zu files):", group_name.c_str(), total_count);
+                            for (size_t i = 0; i < file_names.size(); ++i) {
+                                const auto &group = groups[indices[i]];
+                                ImGui::Text("  %s %s", group.enabled ? "[X]" : "[ ]", file_names[i].c_str());
+                            }
+                            ImGui::Text("Status: %zu of %zu enabled", enabled_count, total_count);
+                        }
+                        ImGui::EndTooltip();
+                    }
+                }
+
+                size_t enabled_count = m_symbol_table.GetEnabledSymbolCount();
+                size_t total_count = m_symbol_table.GetSymbolCount();
+                if (enabled_count == total_count) {
+                    ImGui::Text("Total symbols: %zu", enabled_count);
+                } else {
+                    ImGui::Text("Active symbols: %zu / %zu", enabled_count, total_count);
+                }
             } else {
-                ImGui::TextDisabled("No symbols loaded");
+                ImGui::TextDisabled("No symbol groups loaded");
             }
 
             ImGui::EndMenu();
@@ -3035,6 +3167,15 @@ void BeebWindow::SaveSettings() {
     m_settings.full_screen = this->IsWindowFullScreen();
 #endif
 
+    // Save symbol table state
+    try {
+        m_settings.symbol_table_data = m_symbol_table.SaveToJSON();
+        LOGF(SYMBOLS, "Saved symbol table persistence data with %zu groups\n", m_symbol_table.GetAllGroups().size());
+    } catch (const std::exception &e) {
+        LOGF(SYMBOLS, "ERROR: Failed to save symbol table persistence data: %s\n", e.what());
+        m_settings.symbol_table_data = nlohmann::json{}; // Clear invalid data
+    }
+
     BeebWindows::defaults = m_settings;
     BeebWindows::default_config_name = this->GetConfigName();
 
@@ -3491,21 +3632,183 @@ const SymbolTable &BeebWindow::GetSymbolTable() const {
 //////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////
 
-void BeebWindow::OpenSymbolsFileDialog() {
-    OpenFileDialog fd("symbols");
+// OpenSymbolsFileDialog() removed - now using unified symbol loading dialog
 
-    fd.AddFilter("Symbol files", {".lbl", ".vice", ".sym"});
-    fd.AddAllFilesFilter();
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
 
-    std::string path;
-    if (fd.Open(&path)) {
-        bool success = m_symbol_table.LoadFromFile(path);
-        if (success) {
-            m_msg.i.f("Symbols loaded successfully from: %s\n", path.c_str());
-            fd.AddLastPathToRecentPaths();
-        } else {
-            m_msg.e.f("Failed to load symbols from: %s\n", path.c_str());
+// DoSymbolLoadingDialog() removed - now using unified DoSymbolLoadingWindow()
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+void BeebWindow::DoSymbolLoadingWindow() {
+    static char group_name_buffer[SymbolUI::MAX_GROUP_NAME_LENGTH + 1] = "";
+    static char selected_file_path[SymbolUI::MAX_FILE_PATH_LENGTH + 1] = "";
+    static std::set<char> selected_contexts;
+    static bool show_context_help = false;
+    static bool advanced_section_open = false; // Track if advanced section is expanded
+
+    if (!m_show_enhanced_symbol_window) {
+        return;
+    }
+
+    // Center the window - smaller since we're collapsing advanced options by default
+    ImGuiViewport *main_viewport = ImGui::GetMainViewport();
+    ImVec2 center = main_viewport->GetCenter();
+    ImVec2 window_size = advanced_section_open ? ImVec2(SymbolUI::LOADING_WINDOW_WIDTH_ADVANCED, SymbolUI::LOADING_WINDOW_HEIGHT_ADVANCED) : ImVec2(SymbolUI::LOADING_WINDOW_WIDTH_BASIC, SymbolUI::LOADING_WINDOW_HEIGHT_BASIC);
+    ImVec2 window_pos = ImVec2(center.x - window_size.x * 0.5f, center.y - window_size.y * 0.5f);
+
+    ImGui::SetNextWindowPos(window_pos, ImGuiCond_Appearing);
+    ImGui::SetNextWindowSize(window_size, ImGuiCond_Appearing);
+
+    bool window_open = true;
+    if (ImGui::Begin("Load Symbols", &window_open, ImGuiWindowFlags_NoCollapse)) {
+
+        // File selection (always visible)
+        ImGui::Text("Select Symbol File:");
+        ImGui::InputText("##file_path", selected_file_path, sizeof(selected_file_path), ImGuiInputTextFlags_ReadOnly);
+        ImGui::SameLine();
+        if (ImGui::Button("Browse...")) {
+            OpenFileDialog fd("symbols");
+            fd.AddFilter("Symbol files", {".lbl", ".vice", ".sym"});
+            fd.AddAllFilesFilter();
+
+            std::string path;
+            if (fd.Open(&path)) {
+                strncpy(selected_file_path, path.c_str(), sizeof(selected_file_path) - 1);
+                selected_file_path[sizeof(selected_file_path) - 1] = '\0';
+
+                // Auto-generate group name from filename if advanced section is open
+                if (advanced_section_open && strlen(group_name_buffer) == 0) {
+                    std::string filename = PathGetName(path);
+                    size_t dot_pos = filename.find_last_of('.');
+                    if (dot_pos != std::string::npos) {
+                        filename = filename.substr(0, dot_pos);
+                    }
+                    strncpy(group_name_buffer, filename.c_str(), sizeof(group_name_buffer) - 1);
+                    group_name_buffer[sizeof(group_name_buffer) - 1] = '\0';
+                }
+            }
         }
+
+        ImGui::Separator();
+
+        // Advanced options section (collapsible)
+        if (ImGui::CollapsingHeader("Advanced Options", advanced_section_open ? ImGuiTreeNodeFlags_DefaultOpen : 0)) {
+            advanced_section_open = true;
+
+            // Group name input
+            ImGui::Text("Group Name:");
+            ImGui::InputText("##group_name", group_name_buffer, sizeof(group_name_buffer));
+            if (ImGui::IsItemHovered()) {
+                ImGui::BeginTooltip();
+                ImGui::Text("Name for this symbol group (e.g., 'MOS', 'ROM Bank F', 'My Program')");
+                ImGui::Text("Leave empty to auto-generate from filename");
+                ImGui::EndTooltip();
+            }
+
+            ImGui::Separator();
+
+            // Memory context selection
+            ImGui::Text("Memory Contexts:");
+            ImGui::SameLine();
+
+            // Use shared helper function
+            this->DoMemoryContextSelectionUI(selected_contexts, show_context_help);
+        } else {
+            advanced_section_open = false;
+        }
+
+        ImGui::Separator();
+
+        // Buttons
+        bool can_load = strlen(selected_file_path) > 0;
+
+        if (!can_load) {
+            ImGui::BeginDisabled();
+        }
+        if (ImGui::Button("Load")) {
+            std::string path = selected_file_path;
+            std::string group_name;
+            std::set<char> contexts_to_use;
+
+            // Smart group naming and context handling based on advanced section state
+            if (advanced_section_open) {
+                // Advanced mode: use custom group name or auto-generate from filename
+                group_name = group_name_buffer;
+                if (group_name.empty()) {
+                    // Auto-generate group name from filename
+                    std::string filename = path;
+                    size_t last_slash = filename.find_last_of("/\\");
+                    if (last_slash != std::string::npos) {
+                        filename = filename.substr(last_slash + 1);
+                    }
+                    // Remove extension for cleaner name
+                    size_t last_dot = filename.find_last_of('.');
+                    if (last_dot != std::string::npos) {
+                        filename = filename.substr(0, last_dot);
+                    }
+                    group_name = filename;
+                }
+                contexts_to_use = selected_contexts; // Use selected contexts
+            } else {
+                // Simple mode: use "Global" group name with universal context
+                group_name = "Global";
+                contexts_to_use.clear(); // Universal context (empty set)
+            }
+
+            bool success = m_symbol_table.LoadFromFile(path, group_name, contexts_to_use);
+
+            if (success) {
+                m_msg.i.f("Symbols loaded successfully into group '%s' from: %s\n", group_name.c_str(), path.c_str());
+                if (advanced_section_open && !contexts_to_use.empty()) {
+                    m_msg.i.f("Applied to memory contexts: ");
+                    for (char c : contexts_to_use) {
+                        m_msg.i.f("'%c' ", c);
+                    }
+                    m_msg.i.f("\n");
+                } else if (!advanced_section_open) {
+                    m_msg.i.f("Applied to universal context (visible everywhere)\n");
+                }
+
+                // Reset dialog state and close
+                group_name_buffer[0] = '\0';
+                selected_file_path[0] = '\0';
+                selected_contexts.clear();
+                show_context_help = false;
+                advanced_section_open = false; // Reset to collapsed state for next use
+
+                m_show_enhanced_symbol_window = false;
+                window_open = false;
+            } else {
+                m_msg.e.f("Failed to load symbols from: %s\n", path.c_str());
+            }
+        }
+        if (!can_load) {
+            ImGui::EndDisabled();
+        }
+
+        ImGui::SameLine();
+
+        if (ImGui::Button("Cancel")) {
+            // Reset dialog state and close
+            group_name_buffer[0] = '\0';
+            selected_file_path[0] = '\0';
+            selected_contexts.clear();
+            show_context_help = false;
+            advanced_section_open = false; // Reset to collapsed state for next use
+
+            m_show_enhanced_symbol_window = false;
+            window_open = false;
+        }
+    }
+
+    ImGui::End();
+
+    // Handle window close button
+    if (!window_open) {
+        m_show_enhanced_symbol_window = false;
     }
 }
 
@@ -4018,4 +4321,522 @@ void BeebWindow::ShowPrioritizeCommandShortcutsStatus() {
 
 void BeebWindow::ResetImGuiWindows() {
     m_settings.popups = 0;
+}
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+// Helper function to render memory context selection UI (shared between dialogs)
+void BeebWindow::DoMemoryContextSelectionUI(std::set<char> &selected_contexts, bool &show_context_help) {
+    // Context help
+    if (ImGui::Button("?##context_help")) {
+        show_context_help = !show_context_help;
+    }
+
+    if (show_context_help) {
+        // Calculate height based on number of lines
+        float help_height = ImGui::GetTextLineHeightWithSpacing() * SymbolUI::CONTEXT_HELP_LINES;
+        ImGui::BeginChild("context_help", ImVec2(-1, help_height), false);
+        ImGui::TextWrapped("Memory contexts control when symbols are visible:"); // wraps to 2 lines
+        ImGui::BulletText("'m' - Main RAM");
+        ImGui::BulletText("'o' - OS ROM (MOS)");
+        ImGui::BulletText("'0'-'f' - ROM banks 0-15");
+        ImGui::BulletText("'s' - Shadow RAM");
+        ImGui::BulletText("'n' - ANDY (extra RAM)");
+        ImGui::BulletText("'h' - HAZEL (Master)");
+        ImGui::BulletText("'p' - Parasite RAM");
+        ImGui::BulletText("'r' - Parasite boot ROM");
+        ImGui::BulletText("'i' - I/O area");
+        ImGui::TextWrapped("Leave empty for universal context (visible everywhere)"); // wraps to 2 lines
+        ImGui::EndChild();
+    }
+
+    // Context checkboxes - use organized groups from memory_contexts.h
+    for (const auto &group : MemoryContexts::CONTEXT_GROUPS) {
+        bool is_collapsible = group.collapsible;
+        bool group_is_open = true;
+
+        if (is_collapsible) {
+            group_is_open = ImGui::CollapsingHeader(group.name, ImGuiTreeNodeFlags_None);
+        } else {
+            ImGui::Text("%s:", group.name);
+        }
+
+        if (group_is_open) {
+            for (size_t i = 0; i < group.count; ++i) {
+                const auto &context_info = group.contexts[i];
+                char context = context_info.context;
+                bool selected = selected_contexts.find(context) != selected_contexts.end();
+
+                // Generate label
+                std::string label = std::string("'") + context + "'";
+                if (strlen(context_info.description) > 0) {
+                    label += " " + std::string(context_info.description);
+                }
+
+                if (ImGui::Checkbox(label.c_str(), &selected)) {
+                    if (selected) {
+                        selected_contexts.insert(context);
+                    } else {
+                        selected_contexts.erase(context);
+                    }
+                }
+
+                // Layout logic based on group type
+                if (strcmp(group.name, "ROM Banks 0-15") == 0 || strcmp(group.name, "ROM Mappers (A-P)") == 0) {
+                    // ROM banks: 8 per row
+                    if ((i + 1) % 8 != 0 && i < group.count - 1) {
+                        ImGui::SameLine();
+                    }
+                } else if (i < group.count - 1) {
+                    // Other groups: inline with spacing
+                    ImGui::SameLine();
+                }
+            }
+        }
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+void BeebWindow::DoGroupManagementWindowContent() {
+    // Static selection state for group management
+    static std::vector<bool> selected_groups;
+
+    // Static state for inline editing
+    static int editing_contexts_id = -1;    // Which group's contexts are being edited (-1 = none)
+    static std::set<char> editing_contexts; // Temporary contexts during editing
+    static bool show_context_help = false;  // Help text for context popup
+
+    // Name buffers for each group (persistent across frames)
+    static std::vector<std::string> group_name_buffers;
+
+    ImGui::Text("Manage Symbol Groups and Precedence");
+    ImGui::Separator();
+
+    // Get reference to groups
+    const auto &groups = m_symbol_table.GetAllGroups();
+
+    // Ensure selection state matches group count
+    if (selected_groups.size() != groups.size()) {
+        selected_groups.resize(groups.size(), false);
+    }
+
+    // Ensure name buffers match group count and are initialized
+    if (group_name_buffers.size() != groups.size()) {
+        group_name_buffers.resize(groups.size());
+        for (size_t i = 0; i < groups.size(); ++i) {
+            group_name_buffers[i] = groups[i].name;
+        }
+    }
+
+    if (groups.empty()) {
+        ImGui::Text("No symbol groups loaded.");
+        ImGui::Separator();
+        if (ImGui::Button("Close")) {
+            const uint64_t mask = (uint64_t)1 << BeebWindowPopupType_SymbolGroupManagement;
+            m_settings.popups &= ~mask;
+        }
+    } else {
+        ImGui::Text("Groups are ordered by precedence (lower position = higher precedence)");
+
+        // Show total symbol counts
+        size_t enabled_count = m_symbol_table.GetEnabledSymbolCount();
+        size_t total_count = m_symbol_table.GetSymbolCount();
+        if (enabled_count == total_count) {
+            ImGui::Text("Total symbols: %zu", enabled_count);
+        } else {
+            ImGui::Text("Active symbols: %zu / %zu", enabled_count, total_count);
+        }
+
+        ImGui::Separator();
+
+        // Count selected groups
+        size_t selected_count = 0;
+        for (size_t i = 0; i < selected_groups.size(); ++i) {
+            if (selected_groups[i]) {
+                selected_count++;
+            }
+        }
+
+        // Table setup
+        ImGuiTableFlags table_flags = ImGuiTableFlags_BordersOuter | ImGuiTableFlags_BordersV |
+                                      ImGuiTableFlags_RowBg | ImGuiTableFlags_Resizable;
+
+        // Calculate table height to fit content without excessive scrolling
+        float table_height = ImGui::GetTextLineHeightWithSpacing() * (groups.size() + 1);                                     // +1 for header
+        table_height = std::min(table_height, ImGui::GetContentRegionAvail().y - SymbolUI::MANAGEMENT_TABLE_RESERVED_HEIGHT); // Reserve space for buttons below
+
+        if (ImGui::BeginTable("symbol_groups", 8, table_flags, ImVec2(0.0f, table_height))) {
+            // Reordered columns: # first, then Select, then Move
+            ImGui::TableSetupColumn("#", ImGuiTableColumnFlags_WidthFixed, SymbolUI::COL_INDEX_WIDTH);
+            ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthFixed, SymbolUI::COL_SELECT_WIDTH);
+            ImGui::TableSetupColumn("Move", ImGuiTableColumnFlags_WidthFixed, SymbolUI::COL_MOVE_WIDTH);
+            ImGui::TableSetupColumn("Enabled", ImGuiTableColumnFlags_WidthFixed, SymbolUI::COL_ENABLED_WIDTH);
+            ImGui::TableSetupColumn("Group Name", ImGuiTableColumnFlags_WidthStretch, SymbolUI::COL_GROUP_NAME_WIDTH);
+            ImGui::TableSetupColumn("Count", ImGuiTableColumnFlags_WidthFixed, SymbolUI::COL_COUNT_WIDTH);
+            ImGui::TableSetupColumn("Contexts", ImGuiTableColumnFlags_WidthStretch, SymbolUI::COL_CONTEXTS_WIDTH);
+            ImGui::TableSetupColumn("Source File", ImGuiTableColumnFlags_WidthStretch, SymbolUI::COL_SOURCE_FILE_WIDTH);
+
+            // Show headers
+            ImGui::TableHeadersRow();
+
+            // List all groups
+            for (size_t i = 0; i < groups.size(); ++i) {
+                const auto &group = groups[i];
+
+                ImGui::PushID((int)i);
+                ImGui::TableNextRow();
+
+                // Row selection state
+                bool is_selected = i < selected_groups.size() && selected_groups[i];
+
+                // Apply subtle background color for selected items (not hover highlighting)
+                if (is_selected) {
+                    ImGui::TableSetBgColor(ImGuiTableBgTarget_RowBg1, IM_COL32(70, 140, 200, 40));
+                }
+
+                // Column 0: Order number with row-spanning selectable for hover highlighting (ImGui demo style)
+                ImGui::TableSetColumnIndex(0);
+                char row_label[32];
+                sprintf(row_label, "%zu", i);
+
+                // Use visible Selectable with text content
+                ImGuiSelectableFlags selectable_flags = ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_AllowOverlap;
+                ImGui::Selectable(row_label, false, selectable_flags, ImVec2(0, ImGui::GetFrameHeight()));
+
+                // Store column positions for double-click detection (contexts only)
+                static float contexts_col_start = 0;
+                static float contexts_col_end = 0;
+
+                // Handle double-click on row for context editing
+                if (ImGui::IsItemHovered() && ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left)) {
+                    ImVec2 mouse_pos = ImGui::GetMousePos();
+
+                    // Check if double-click was in Contexts column
+                    if (mouse_pos.x >= contexts_col_start && mouse_pos.x < contexts_col_end) {
+                        editing_contexts_id = static_cast<int>(i);
+                        editing_contexts = group.memory_contexts;
+                    }
+                }
+
+                // Column 1: Selection checkbox - centered
+                ImGui::TableSetColumnIndex(1);
+                // Center the checkbox in the column
+                float column_width = ImGui::GetColumnWidth();
+                float checkbox_width = ImGui::GetFrameHeight(); // Checkbox is square
+                float center_offset = (column_width - checkbox_width) * 0.5f;
+                ImGui::SetCursorPosX(ImGui::GetCursorPosX() + center_offset);
+
+                bool selected = is_selected;
+                std::string select_id = "##select_" + std::to_string(i);
+                if (ImGui::Checkbox(select_id.c_str(), &selected)) {
+                    selected_groups[i] = selected;
+                }
+
+                // Column 2: Move buttons
+                ImGui::TableSetColumnIndex(2);
+                // Up button
+                if (i > 0) { // Can't move above first position
+                    if (ImGui::ArrowButton("##up", ImGuiDir_Up)) {
+                        if (m_symbol_table.MoveGroup(i, i - 1)) {
+                            // Swap selection states too
+                            if (i < selected_groups.size() && i - 1 < selected_groups.size()) {
+                                bool temp = selected_groups[i];
+                                selected_groups[i] = selected_groups[i - 1];
+                                selected_groups[i - 1] = temp;
+                            }
+                            // Swap name buffers too
+                            if (i < group_name_buffers.size() && i - 1 < group_name_buffers.size()) {
+                                std::swap(group_name_buffers[i], group_name_buffers[i - 1]);
+                            }
+                        }
+                    }
+                } else {
+                    ImGui::Dummy(ImVec2(ImGui::GetFrameHeight(), ImGui::GetFrameHeight()));
+                }
+
+                ImGui::SameLine(0, 2); // Tight spacing
+
+                // Down button
+                if (i < groups.size() - 1) { // Can't move below last position
+                    if (ImGui::ArrowButton("##down", ImGuiDir_Down)) {
+                        if (m_symbol_table.MoveGroup(i, i + 1)) {
+                            // Swap selection states too
+                            if (i < selected_groups.size() && i + 1 < selected_groups.size()) {
+                                bool temp = selected_groups[i];
+                                selected_groups[i] = selected_groups[i + 1];
+                                selected_groups[i + 1] = temp;
+                            }
+                            // Swap name buffers too
+                            if (i < group_name_buffers.size() && i + 1 < group_name_buffers.size()) {
+                                std::swap(group_name_buffers[i], group_name_buffers[i + 1]);
+                            }
+                        }
+                    }
+                } else {
+                    ImGui::Dummy(ImVec2(ImGui::GetFrameHeight(), ImGui::GetFrameHeight()));
+                }
+
+                // Column 3: Enabled checkbox - centered
+                ImGui::TableSetColumnIndex(3);
+                // Center the checkbox in the column
+                float enabled_column_width = ImGui::GetColumnWidth();
+                float enabled_checkbox_width = ImGui::GetFrameHeight(); // Checkbox is square
+                float enabled_center_offset = (enabled_column_width - enabled_checkbox_width) * 0.5f;
+                ImGui::SetCursorPosX(ImGui::GetCursorPosX() + enabled_center_offset);
+
+                bool enabled = group.enabled;
+                std::string checkbox_id = "##enabled_" + std::to_string(i);
+                if (ImGui::Checkbox(checkbox_id.c_str(), &enabled)) {
+                    m_symbol_table.EnableGroup(i, enabled);
+                }
+
+                // Column 4: Group name (always editable input field)
+                ImGui::TableSetColumnIndex(4);
+
+                // Always show as InputText - much simpler and more intuitive
+                std::string input_id = "##group_name_" + std::to_string(i);
+                char buffer[SymbolUI::MAX_GROUP_NAME_LENGTH + 1];
+                strncpy(buffer, group_name_buffers[i].c_str(), 255);
+                buffer[255] = '\0';
+
+                // Make InputText fill the column width
+                ImGui::SetNextItemWidth(ImGui::GetColumnWidth());
+
+                if (ImGui::InputText(input_id.c_str(), buffer, sizeof(buffer))) {
+                    // Text changed - update buffer
+                    group_name_buffers[i] = buffer;
+                }
+
+                // Save changes when Enter pressed or focus lost
+                if (ImGui::IsItemDeactivatedAfterEdit()) {
+                    std::string new_name = group_name_buffers[i];
+                    if (new_name != group.name) {
+                        m_symbol_table.SetGroupName(i, new_name);
+                    }
+                }
+
+                // Right-click context menu for the group name
+                std::string popup_id = "group_context_menu_" + std::to_string(i);
+                if (ImGui::BeginPopupContextItem(popup_id.c_str())) {
+                    std::string display_name = group.name.empty() ? "Unnamed Group" : group.name;
+                    ImGui::Text("Group: %s", display_name.c_str());
+                    ImGui::Separator();
+                    if (ImGui::MenuItem("Delete")) {
+                        m_symbol_table.RemoveGroup(i);
+                    }
+                    ImGui::EndPopup();
+                }
+
+                // Column 5: Symbol count for this group
+                ImGui::TableSetColumnIndex(5);
+                size_t group_symbol_count = m_symbol_table.GetSymbolCountForGroup(i);
+                ImGui::Text("%zu", group_symbol_count);
+                if (ImGui::IsItemHovered()) {
+                    ImGui::BeginTooltip();
+                    ImGui::Text("Number of symbols in this group");
+                    if (group_symbol_count > 0) {
+                        if (group.enabled) {
+                            ImGui::Text("All %zu symbols are active", group_symbol_count);
+                        } else {
+                            ImGui::Text("All %zu symbols are disabled", group_symbol_count);
+                        }
+                    }
+                    ImGui::EndTooltip();
+                }
+
+                // Column 6: Contexts (with double-click editing)
+                ImGui::TableSetColumnIndex(6);
+
+                // Store column position for double-click detection
+                contexts_col_start = ImGui::GetCursorScreenPos().x;
+                contexts_col_end = contexts_col_start + ImGui::GetColumnWidth();
+
+                // Display contexts (clickable) - show all contexts, no truncation
+                std::string display_text;
+                if (group.memory_contexts.empty()) {
+                    display_text = "Universal";
+                } else {
+                    // Show all contexts - user can resize column if needed
+                    for (char c : group.memory_contexts) {
+                        if (!display_text.empty())
+                            display_text += " ";
+                        display_text += c;
+                    }
+                }
+
+                ImGui::Text("%s", display_text.c_str());
+
+                if (ImGui::IsItemHovered()) {
+                    ImGui::BeginTooltip();
+                    ImGui::Text("Double-click to edit");
+                    ImGui::EndTooltip();
+                }
+
+                // Column 7: Source file
+                ImGui::TableSetColumnIndex(7);
+                if (group.file_path.empty()) {
+                    ImGui::Text("-");
+                } else {
+                    // Show just filename
+                    std::string filename = group.file_path;
+                    size_t slash_pos = filename.find_last_of("/\\");
+                    if (slash_pos != std::string::npos) {
+                        filename = filename.substr(slash_pos + 1);
+                    }
+                    ImGui::Text("%s", filename.c_str());
+
+                    if (ImGui::IsItemHovered()) {
+                        ImGui::BeginTooltip();
+                        ImGui::Text("Full path: %s", group.file_path.c_str());
+                        ImGui::EndTooltip();
+                    }
+                }
+
+                ImGui::PopID();
+            }
+
+            ImGui::EndTable();
+        }
+
+        ImGui::Separator();
+
+        // Action buttons
+        if (ImGui::Button("Close")) {
+            const uint64_t mask = (uint64_t)1 << BeebWindowPopupType_SymbolGroupManagement;
+            m_settings.popups &= ~mask;
+        }
+
+        ImGui::SameLine();
+
+        // Multi-delete button
+        if (selected_count == 0) {
+            ImGui::BeginDisabled();
+        }
+
+        if (ImGui::Button("Delete Selected")) {
+            // Delete groups from highest index to lowest to maintain indices
+            for (int idx = static_cast<int>(selected_groups.size()) - 1; idx >= 0; --idx) {
+                if (selected_groups[static_cast<size_t>(idx)]) {
+                    m_symbol_table.RemoveGroup(static_cast<size_t>(idx));
+                }
+            }
+            // Reset selection state
+            selected_groups.clear();
+        }
+
+        if (selected_count == 0) {
+            ImGui::EndDisabled();
+            if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+                ImGui::SetTooltip("Select one or more groups to delete");
+            }
+        } else {
+            if (ImGui::IsItemHovered()) {
+                ImGui::SetTooltip("Delete %zu selected group%s", selected_count, selected_count > 1 ? "s" : "");
+            }
+        }
+    }
+
+    // Context editing popup (modal dialog)
+    if (editing_contexts_id != -1) {
+        // Open the popup immediately when editing is triggered
+        ImGui::OpenPopup("Edit Memory Contexts");
+
+        // Center the popup - make it wider to accommodate help text
+        ImGuiViewport *main_viewport = ImGui::GetMainViewport();
+        ImVec2 center = main_viewport->GetCenter();
+        ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+        ImGui::SetNextWindowSize(ImVec2(SymbolUI::CONTEXT_MODAL_WIDTH, SymbolUI::CONTEXT_MODAL_HEIGHT), ImGuiCond_Appearing);
+
+        if (ImGui::BeginPopupModal("Edit Memory Contexts", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+
+            const auto &groups = m_symbol_table.GetAllGroups();
+            if (editing_contexts_id >= 0 && static_cast<size_t>(editing_contexts_id) < groups.size()) {
+                const SymbolTable::SymbolGroup &group = groups[static_cast<size_t>(editing_contexts_id)];
+
+                ImGui::Text("Editing contexts for group: %s", group.name.c_str());
+                ImGui::Separator();
+
+                // Use shared helper function for context selection
+                this->DoMemoryContextSelectionUI(editing_contexts, show_context_help);
+
+                ImGui::Separator();
+
+                // Action buttons
+                if (ImGui::Button("Save") || ImGui::IsKeyPressed(ImGuiKey_Enter)) {
+                    m_symbol_table.SetGroupContexts(static_cast<size_t>(editing_contexts_id), editing_contexts);
+                    editing_contexts_id = -1;
+                    show_context_help = false;
+                    ImGui::CloseCurrentPopup();
+                }
+
+                ImGui::SameLine();
+
+                if (ImGui::Button("Cancel") || ImGui::IsKeyPressed(ImGuiKey_Escape)) {
+                    editing_contexts_id = -1;
+                    show_context_help = false;
+                    ImGui::CloseCurrentPopup();
+                }
+            } else {
+                // Invalid group ID - close popup
+                editing_contexts_id = -1;
+                ImGui::CloseCurrentPopup();
+            }
+
+            ImGui::EndPopup();
+        }
+
+        // If popup was closed externally, reset editing state
+        if (!ImGui::IsPopupOpen("Edit Memory Contexts")) {
+            editing_contexts_id = -1;
+            show_context_help = false;
+        }
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+class SymbolGroupManagementUI : public SettingsUI {
+  public:
+    explicit SymbolGroupManagementUI(BeebWindow *beeb_window);
+
+    void DoImGui() override;
+    bool OnClose() override;
+
+  private:
+    BeebWindow *m_beeb_window = nullptr;
+};
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+SymbolGroupManagementUI::SymbolGroupManagementUI(BeebWindow *beeb_window)
+    : m_beeb_window(beeb_window) {
+    this->SetDefaultSize(ImVec2(SymbolUI::MANAGEMENT_WINDOW_WIDTH, SymbolUI::MANAGEMENT_WINDOW_HEIGHT));
+}
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+void SymbolGroupManagementUI::DoImGui() {
+    // Just call the existing implementation but without the popup system checks
+    // since those are handled by the SettingsUI system
+    m_beeb_window->DoGroupManagementWindowContent();
+}
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+bool SymbolGroupManagementUI::OnClose() {
+    return false; // Don't save config on close
+}
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+std::unique_ptr<SettingsUI> CreateSymbolGroupManagementWindow(BeebWindow *beeb_window) {
+    return std::make_unique<SymbolGroupManagementUI>(beeb_window);
 }

--- a/src/b2/BeebWindow.h
+++ b/src/b2/BeebWindow.h
@@ -123,9 +123,11 @@ struct BeebWindowSettings {
     std::shared_ptr<JSON> popup_persistent_data[BeebWindowPopupType_MaxValue]; //json:annoying one-off data type
 
     DebuggerSyntax debugger_syntax{DebuggerSyntax_BBCBASIC};
+
+    nlohmann::json symbol_table_data; // JSON object for symbol table persistence
 };
 JSON_SERIALIZE(BeebWindowSettings::CopySettings, convert_mode, handle_delete);
-JSON_SERIALIZE(BeebWindowSettings, bbc_volume, bbc_mute, disc_volume, disc_mute, power_on_tone, correct_aspect_ratio, screenshot_last_vsync, screenshot_correct_aspect_ratio, display_interlace, screenshot_filter, gui_font_size, full_screen, prefer_shortcuts, leds_popup_mode, leds_popup_alpha, text_copy_settings, printer_copy_settings, capture_mouse_on_click, low_pass_filter, low_pass_filter_cutoff_hz, hide_cursor_when_unfocused, background_economy_mode, debugger_syntax);
+JSON_SERIALIZE(BeebWindowSettings, bbc_volume, bbc_mute, disc_volume, disc_mute, power_on_tone, correct_aspect_ratio, screenshot_last_vsync, screenshot_correct_aspect_ratio, display_interlace, screenshot_filter, gui_font_size, full_screen, prefer_shortcuts, leds_popup_mode, leds_popup_alpha, text_copy_settings, printer_copy_settings, capture_mouse_on_click, low_pass_filter, low_pass_filter_cutoff_hz, hide_cursor_when_unfocused, background_economy_mode, debugger_syntax, symbol_table_data);
 
 //////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////
@@ -311,7 +313,15 @@ class BeebWindow {
     const SymbolTable &GetSymbolTable() const;
 
     // Symbol file loading
-    void OpenSymbolsFileDialog();
+    // Unified symbol loading dialog (replaces old Simple/Enhanced distinction)
+    void DoSymbolLoadingWindow();
+    void DoGroupManagementWindowContent(); // Content only, for SettingsUI integration
+
+    // Helper function for memory context selection UI (shared between dialogs)
+    void DoMemoryContextSelectionUI(std::set<char> &selected_contexts, bool &show_context_help);
+
+    // Enhanced symbol loading state
+    bool m_show_enhanced_symbol_window = false;
 
     bool HardReset(const BeebConfig &config, uint32_t flags);
 

--- a/src/b2/BeebWindow.inl
+++ b/src/b2/BeebWindow.inl
@@ -80,6 +80,7 @@ EPN(DiskDriveDebug)
 EPN(HardDiskDebug)
 EPN(SCSIDebug)
 EPN(SerialDebug) //55
+EPN(SymbolGroupManagement)
 
 // must be last
 EQPN(MaxValue)

--- a/src/b2/CMakeLists.txt
+++ b/src/b2/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(b2 MACOSX_BUNDLE
   SavedStatesUI.cpp SavedStatesUI.h
   SettingsUI.cpp SettingsUI.h
   SymbolTable.cpp SymbolTable.h
+  memory_contexts.cpp memory_contexts.h symbol_ui_constants.h
   ThumbnailsUI.cpp ThumbnailsUI.h ThumbnailsUI_private.inl
   TimelineUI.cpp TimelineUI.h
   TraceUI.cpp TraceUI.h TraceUI.inl

--- a/src/b2/SymbolTable.cpp
+++ b/src/b2/SymbolTable.cpp
@@ -1,10 +1,14 @@
 #include <shared/system.h>
 #include "SymbolTable.h"
+#include "memory_contexts.h"
 #include <shared/log.h>
 #include <fstream>
 #include <sstream>
 #include <regex>
 #include <algorithm>
+#include <unordered_map>
+#include <memory>
+#include <vector>
 
 //////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////
@@ -14,7 +18,9 @@ LOG_DEFINE(SYMBOLS, "SYMBOLS", &log_printer_stdout_and_debugger, false);
 //////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////
 
-SymbolTable::SymbolTable() {
+SymbolTable::SymbolTable()
+    : m_cache_dirty(false) {
+    // No default group needed - all loads create named groups
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -27,16 +33,26 @@ SymbolTable::~SymbolTable() {
 //////////////////////////////////////////////////////////////////////////
 
 void SymbolTable::Clear() {
-    m_address_to_symbol.clear();
-    m_name_to_address.clear();
+    m_address_to_symbols.clear();
+    m_name_to_addresses.clear();
+    m_groups.clear();
+    this->InvalidateCache();
     LOGF(SYMBOLS, "Symbol table cleared\n");
 }
 
 //////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////
 
-bool SymbolTable::LoadFromFile(const std::string &filepath) {
+bool SymbolTable::LoadFromFile(const std::string &filepath, const std::string &group_name, const std::set<char> &memory_contexts) {
     LOGF(SYMBOLS, "Loading symbols from: %s\n", filepath.c_str());
+
+    // Validate all memory contexts before proceeding
+    for (char context : memory_contexts) {
+        if (!MemoryContexts::IsValidContext(context)) {
+            LOGF(SYMBOLS, "ERROR: Invalid memory context '%c' in file: %s\n", context, filepath.c_str());
+            return false;
+        }
+    }
 
     std::ifstream file(filepath);
     if (!file.is_open()) {
@@ -50,20 +66,23 @@ bool SymbolTable::LoadFromFile(const std::string &filepath) {
     std::string content = content_stream.str();
     file.close();
 
-    // Clear existing symbols before loading new ones
+    // Always create a new group for each file loaded
+    std::string actual_group_name = group_name.empty() ? "Global" : group_name;
+
+    // Create new group - names are just display labels, can be duplicated
+    SymbolGroup new_group(actual_group_name, "Loaded from " + filepath, filepath);
+    new_group.memory_contexts = memory_contexts;
+    size_t group_id = this->AddGroup(new_group);
+
     size_t old_count = GetSymbolCount();
-    Clear();
 
-    // Try to detect format and load
-    bool success = false;
-
-    // For now, assume VICE format - can add format detection later
-    success = LoadViceFormat(content);
+    // Detect format and load with appropriate parser
+    bool success = LoadFromContent(content, group_id);
 
     if (success) {
         size_t new_count = GetSymbolCount();
-        LOGF(SYMBOLS, "Successfully loaded %zu symbols (replaced %zu existing)\n",
-             new_count, old_count);
+        LOGF(SYMBOLS, "Successfully loaded %zu symbols into group '%s' (%zu symbols total)\n",
+             new_count - old_count, actual_group_name.c_str(), new_count);
     } else {
         LOGF(SYMBOLS, "ERROR: Failed to parse symbol file: %s\n", filepath.c_str());
     }
@@ -74,7 +93,163 @@ bool SymbolTable::LoadFromFile(const std::string &filepath) {
 //////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////
 
-bool SymbolTable::LoadViceFormat(const std::string &content) {
+// SymbolParserRegistry implementation
+std::vector<std::unique_ptr<SymbolTable::SymbolParser>> SymbolTable::SymbolParserRegistry::s_parsers;
+
+void SymbolTable::SymbolParserRegistry::RegisterParser(std::unique_ptr<SymbolParser> parser) {
+    s_parsers.push_back(std::move(parser));
+}
+
+const std::vector<std::unique_ptr<SymbolTable::SymbolParser>> &SymbolTable::SymbolParserRegistry::GetParsers() {
+    return s_parsers;
+}
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+// Concrete parser implementations
+
+class ViceParser : public SymbolTable::SymbolParser {
+  public:
+    std::string GetFormatName() const override {
+        return "VICE";
+    }
+
+    bool MatchesLine(const std::string &line) const override {
+        // Skip empty lines and comments
+        if (line.empty() || line[0] == ';' || line[0] == '#') {
+            return false;
+        }
+
+        // Check for VICE format: "al FFFF symbol_name"
+        std::regex pattern(R"(^\s*al\s+(?:[A-Za-z0-9]:)?[0-9a-fA-F]{4,6}\s+.+)");
+        return std::regex_match(line, pattern);
+    }
+
+    bool ParseContent(const std::string &content, size_t group_id, SymbolTable *table) override {
+        return table->LoadViceFormat(content, group_id);
+    }
+};
+
+class AcmeParser : public SymbolTable::SymbolParser {
+  public:
+    std::string GetFormatName() const override {
+        return "ACME";
+    }
+
+    bool MatchesLine(const std::string &line) const override {
+        // Skip empty lines and comments
+        if (line.empty() || line[0] == ';' || line[0] == '#') {
+            return false;
+        }
+
+        // Check for ACME format: "symbol_name = address"
+        std::regex pattern(R"(^\s*[a-zA-Z_][a-zA-Z0-9_]*\s*=\s*\$?[0-9a-fA-F]+\s*$)");
+        return std::regex_match(line, pattern);
+    }
+
+    bool ParseContent(const std::string &content, size_t group_id, SymbolTable *table) override {
+        return table->LoadAcmeFormat(content, group_id);
+    }
+};
+
+void SymbolTable::SymbolParserRegistry::InitializeBuiltinParsers() {
+    if (s_parsers.empty()) {
+        RegisterParser(std::make_unique<ViceParser>());
+        RegisterParser(std::make_unique<AcmeParser>());
+        LOGF(SYMBOLS, "Initialized %zu builtin symbol parsers\n", s_parsers.size());
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+SymbolTable::SymbolParser *SymbolTable::DetectBestParser(const std::string &content) {
+    // Ensure builtin parsers are registered
+    SymbolParserRegistry::InitializeBuiltinParsers();
+
+    const auto &parsers = SymbolParserRegistry::GetParsers();
+    if (parsers.empty()) {
+        LOGF(SYMBOLS, "ERROR: No symbol parsers registered!\n");
+        return nullptr;
+    }
+
+    std::istringstream stream(content);
+    std::string line;
+    int lines_checked = 0;
+
+    // Track score for each parser
+    std::vector<int> parser_scores(parsers.size(), 0);
+
+    // Check first 20 non-empty, non-comment lines
+    while (std::getline(stream, line) && lines_checked < 20) {
+        // Skip empty lines and comments for counting
+        if (line.empty() || line[0] == ';' || line[0] == '#') {
+            continue;
+        }
+
+        lines_checked++;
+
+        // Test line against all registered parsers
+        for (size_t i = 0; i < parsers.size(); ++i) {
+            if (parsers[i]->MatchesLine(line)) {
+                parser_scores[i]++;
+            }
+        }
+    }
+
+    // Find parser with highest score (must be >50% confidence)
+    double confidence_threshold = 0.5;
+    int max_score = 0;
+    size_t best_parser_index = 0;
+    bool found_parser = false;
+
+    for (size_t i = 0; i < parser_scores.size(); ++i) {
+        LOGF(SYMBOLS, "Parser '%s': %d/%d matches (%.1f%%)\n",
+             parsers[i]->GetFormatName().c_str(), parser_scores[i], lines_checked,
+             lines_checked > 0 ? (double)parser_scores[i] / lines_checked * 100 : 0);
+
+        if (parser_scores[i] > max_score) {
+            max_score = parser_scores[i];
+            best_parser_index = i;
+        }
+    }
+
+    // Check if best parser meets confidence threshold
+    if (lines_checked > 0 && max_score >= (confidence_threshold * lines_checked)) {
+        found_parser = true;
+        LOGF(SYMBOLS, "Selected parser '%s' with %.1f%% confidence\n",
+             parsers[best_parser_index]->GetFormatName().c_str(),
+             (double)max_score / lines_checked * 100);
+    } else {
+        LOGF(SYMBOLS, "No parser met confidence threshold (need >%.0f%% match)\n",
+             confidence_threshold * 100);
+    }
+
+    return found_parser ? parsers[best_parser_index].get() : nullptr;
+}
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+bool SymbolTable::LoadFromContent(const std::string &content, size_t group_id) {
+    // Use new registry-based detection to get the best parser directly
+    SymbolParser *best_parser = DetectBestParser(content);
+
+    if (best_parser) {
+        LOGF(SYMBOLS, "Using %s parser for content loading\n", best_parser->GetFormatName().c_str());
+        return best_parser->ParseContent(content, group_id, this);
+    }
+
+    // Fallback to VICE format if no parser found
+    LOGF(SYMBOLS, "WARNING: No suitable parser found\n");
+    return false;
+}
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+bool SymbolTable::LoadViceFormat(const std::string &content, size_t group_id) {
     LOGF(SYMBOLS, "Parsing VICE label format\n");
 
     std::istringstream stream(content);
@@ -82,9 +257,9 @@ bool SymbolTable::LoadViceFormat(const std::string &content) {
     size_t line_number = 0;
     size_t symbols_loaded = 0;
 
-    // VICE format: "al 00FFFF ._some_symbol"
-    // More flexible regex to handle variations
-    std::regex pattern(R"(^\s*al\s+([0-9a-fA-F]{4,6})\s+(.+?)\s*$)");
+    // VICE format: "al 00FFFF ._some_symbol" or "al C:FFFF ._some_symbol"
+    // Extended regex to handle memory context prefixes
+    std::regex pattern(R"(^\s*al\s+(?:([A-Za-z0-9]):)?([0-9a-fA-F]{4,6})\s+(.+?)\s*$)");
 
     while (std::getline(stream, line)) {
         line_number++;
@@ -97,8 +272,12 @@ bool SymbolTable::LoadViceFormat(const std::string &content) {
         std::smatch matches;
         if (std::regex_match(line, matches, pattern)) {
             try {
-                uint32_t addr = std::stoul(matches[1].str(), nullptr, 16);
-                std::string name = TrimWhitespace(matches[2].str());
+                // Extract memory context (if present) and address
+                std::string context_str = matches[1].str();
+                uint32_t addr = std::stoul(matches[2].str(), nullptr, 16);
+                std::string name = TrimWhitespace(matches[3].str());
+
+                // Ignore any VICE format context prefixes - contexts are assigned only through UI
 
                 // Strip leading dot from VICE format symbols
                 if (name.length() > 0 && name[0] == '.') {
@@ -106,20 +285,154 @@ bool SymbolTable::LoadViceFormat(const std::string &content) {
                 }
 
                 if (IsValidAddress(addr) && !name.empty()) {
-                    Symbol symbol((uint16_t)addr, name);
+                    Symbol symbol((uint16_t)addr, name, group_id);
 
-                    // Check for duplicate addresses or names
-                    if (m_address_to_symbol.find(symbol.address) != m_address_to_symbol.end()) {
-                        LOGF(SYMBOLS, "WARNING: Duplicate address $%04X at line %zu, overwriting\n",
-                             symbol.address, line_number);
-                    }
-                    if (m_name_to_address.find(name) != m_name_to_address.end()) {
-                        LOGF(SYMBOLS, "WARNING: Duplicate symbol name '%s' at line %zu, overwriting\n",
-                             name.c_str(), line_number);
+                    // Check for duplicates - we allow multiple symbols per address, even from same group
+                    auto existing_addr = m_address_to_symbols.find(symbol.address);
+                    if (existing_addr != m_address_to_symbols.end()) {
+                        // Check if exact same name from same group already exists
+                        bool exact_duplicate_found = false;
+                        for (const Symbol &existing : existing_addr->second) {
+                            if (existing.name == symbol.name && existing.group_id == symbol.group_id) {
+                                LOGF(SYMBOLS, "WARNING: Exact duplicate symbol '%s' at $%04X from group %zu at line %zu, skipping\n",
+                                     symbol.name.c_str(), symbol.address, symbol.group_id, line_number);
+                                exact_duplicate_found = true;
+                                break;
+                            }
+                        }
+                        if (exact_duplicate_found) {
+                            continue; // Skip exact duplicates
+                        }
+
+                        // Log addition of new symbol at existing address
+                        bool same_group_different_name = false;
+                        for (const Symbol &existing : existing_addr->second) {
+                            if (existing.group_id == symbol.group_id && existing.name != symbol.name) {
+                                same_group_different_name = true;
+                                break;
+                            }
+                        }
+
+                        if (same_group_different_name) {
+                            LOGF(SYMBOLS, "INFO: Adding symbol '%s' at $%04X (overrides earlier symbols from same group, CC65-style)\n",
+                                 symbol.name.c_str(), symbol.address);
+                        } else {
+                            LOGF(SYMBOLS, "INFO: Adding symbol '%s' at $%04X from group %zu (total at address: %zu)\n",
+                                 symbol.name.c_str(), symbol.address, symbol.group_id, existing_addr->second.size() + 1);
+                        }
                     }
 
-                    m_address_to_symbol[symbol.address] = symbol;
-                    m_name_to_address[symbol.name] = symbol.address;
+                    // Add symbol to address mapping (append to vector)
+                    m_address_to_symbols[symbol.address].push_back(symbol);
+
+                    // Add symbol to name mapping (multimap allows duplicates)
+                    m_name_to_addresses.insert({symbol.name, symbol.address});
+                    this->InvalidateCache();
+                    symbols_loaded++;
+                } else {
+                    LOGF(SYMBOLS, "WARNING: Invalid symbol at line %zu: address=$%X, name='%s'\n",
+                         line_number, addr, name.c_str());
+                }
+            } catch (const std::exception &e) {
+                LOGF(SYMBOLS, "WARNING: Parse error at line %zu: %s\n", line_number, e.what());
+            }
+        } else {
+            // Only log non-empty, non-comment lines that don't match
+            std::string trimmed = TrimWhitespace(line);
+            if (!trimmed.empty()) {
+                LOGF(SYMBOLS, "WARNING: Unrecognized format at line %zu: '%s'\n",
+                     line_number, trimmed.c_str());
+            }
+        }
+    }
+
+    LOGF(SYMBOLS, "Parsed %zu lines, loaded %zu symbols\n", line_number, symbols_loaded);
+    return symbols_loaded > 0;
+}
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+bool SymbolTable::LoadAcmeFormat(const std::string &content, size_t group_id) {
+    LOGF(SYMBOLS, "Parsing ACME label format\n");
+
+    std::istringstream stream(content);
+    std::string line;
+    size_t line_number = 0;
+    size_t symbols_loaded = 0;
+
+    // ACME format: "symbol_name = address" where address can be:
+    // - $FFFF (hexadecimal with $ prefix)
+    // - 1234 (decimal number)
+    std::regex pattern(R"(^\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*(\$?[0-9a-fA-F]+)\s*$)");
+
+    while (std::getline(stream, line)) {
+        line_number++;
+
+        // Skip empty lines and comments
+        if (line.empty() || line[0] == ';' || line[0] == '#') {
+            continue;
+        }
+
+        std::smatch matches;
+        if (std::regex_match(line, matches, pattern)) {
+            try {
+                std::string name = TrimWhitespace(matches[1].str());
+                std::string addr_str = TrimWhitespace(matches[2].str());
+
+                uint32_t addr;
+                if (addr_str[0] == '$') {
+                    // Hexadecimal address with $ prefix
+                    addr = std::stoul(addr_str.substr(1), nullptr, 16);
+                } else {
+                    // Decimal address
+                    addr = std::stoul(addr_str, nullptr, 10);
+                }
+
+                if (IsValidAddress(addr) && !name.empty()) {
+                    Symbol symbol((uint16_t)addr, name, group_id);
+
+                    // Check for duplicates - we allow multiple symbols per address, even from same group
+                    auto existing_addr = m_address_to_symbols.find(symbol.address);
+                    if (existing_addr != m_address_to_symbols.end()) {
+                        // Check if exact same name from same group already exists
+                        bool exact_duplicate_found = false;
+                        for (const Symbol &existing : existing_addr->second) {
+                            if (existing.name == symbol.name && existing.group_id == symbol.group_id) {
+                                LOGF(SYMBOLS, "WARNING: Exact duplicate symbol '%s' at $%04X from group %zu at line %zu, skipping\n",
+                                     symbol.name.c_str(), symbol.address, symbol.group_id, line_number);
+                                exact_duplicate_found = true;
+                                break;
+                            }
+                        }
+                        if (exact_duplicate_found) {
+                            continue; // Skip exact duplicates
+                        }
+
+                        // Log addition of new symbol at existing address
+                        bool same_group_different_name = false;
+                        for (const Symbol &existing : existing_addr->second) {
+                            if (existing.group_id == symbol.group_id && existing.name != symbol.name) {
+                                same_group_different_name = true;
+                                break;
+                            }
+                        }
+
+                        if (same_group_different_name) {
+                            LOGF(SYMBOLS, "INFO: Adding symbol '%s' at $%04X (overrides earlier symbols from same group, ACME-style)\n",
+                                 symbol.name.c_str(), symbol.address);
+                        } else {
+                            LOGF(SYMBOLS, "INFO: Adding symbol '%s' at $%04X from group %zu (total at address: %zu)\n",
+                                 symbol.name.c_str(), symbol.address, symbol.group_id, existing_addr->second.size() + 1);
+                        }
+                    }
+
+                    // Add symbol to address mapping (append to vector)
+                    m_address_to_symbols[symbol.address].push_back(symbol);
+
+                    // Add symbol to name mapping (multimap allows duplicates)
+                    m_name_to_addresses.insert({symbol.name, symbol.address});
+                    this->InvalidateCache();
                     symbols_loaded++;
                 } else {
                     LOGF(SYMBOLS, "WARNING: Invalid symbol at line %zu: address=$%X, name='%s'\n",
@@ -146,37 +459,89 @@ bool SymbolTable::LoadViceFormat(const std::string &content) {
 //////////////////////////////////////////////////////////////////////////
 
 size_t SymbolTable::GetSymbolCount() const {
-    return m_address_to_symbol.size();
+    size_t count = 0;
+    for (const auto &pair : m_address_to_symbols) {
+        count += pair.second.size();
+    }
+    return count;
+}
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+size_t SymbolTable::GetEnabledSymbolCount() const {
+    size_t count = 0;
+    for (const auto &pair : m_address_to_symbols) {
+        for (const Symbol &symbol : pair.second) {
+            if (symbol.group_id < m_groups.size() && m_groups[symbol.group_id].enabled) {
+                count++;
+            }
+        }
+    }
+    return count;
+}
+
+size_t SymbolTable::GetSymbolCountForGroup(size_t group_id) const {
+    if (group_id >= m_groups.size()) {
+        return 0;
+    }
+
+    size_t count = 0;
+    for (const auto &pair : m_address_to_symbols) {
+        for (const Symbol &symbol : pair.second) {
+            if (symbol.group_id == group_id) {
+                count++;
+            }
+        }
+    }
+    return count;
 }
 
 //////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////
 
 const SymbolTable::Symbol *SymbolTable::GetSymbolForAddress(uint16_t address) const {
-    auto it = m_address_to_symbol.find(address);
-    return (it != m_address_to_symbol.end()) ? &it->second : nullptr;
+    // Return first enabled symbol at this address
+    return this->GetFirstEnabledSymbolAt(address);
 }
 
 //////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////
 
 uint16_t SymbolTable::GetAddressForSymbol(const std::string &name) const {
-    auto it = m_name_to_address.find(name);
-    return (it != m_name_to_address.end()) ? it->second : 0;
+    // Find ANY enabled symbol with this name (not just the "best" one for display)
+    auto range = m_name_to_addresses.equal_range(name);
+    for (auto it = range.first; it != range.second; ++it) {
+        uint16_t address = it->second;
+
+        // Check if there's an enabled symbol with this exact name at this address
+        auto addr_it = m_address_to_symbols.find(address);
+        if (addr_it != m_address_to_symbols.end()) {
+            for (const Symbol &symbol : addr_it->second) {
+                if (symbol.name == name &&
+                    symbol.group_id < m_groups.size() &&
+                    m_groups[symbol.group_id].enabled) {
+                    return address; // Found an enabled symbol with this exact name
+                }
+            }
+        }
+    }
+    return 0;
 }
 
 //////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////
 
 bool SymbolTable::HasSymbolForAddress(uint16_t address) const {
-    return m_address_to_symbol.find(address) != m_address_to_symbol.end();
+    return this->GetSymbolForAddress(address) != nullptr;
 }
 
 //////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////
 
 bool SymbolTable::HasSymbol(const std::string &name) const {
-    return m_name_to_address.find(name) != m_name_to_address.end();
+    // Check if ANY enabled symbol with this name exists
+    return this->GetAddressForSymbol(name) != 0;
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -185,16 +550,29 @@ bool SymbolTable::HasSymbol(const std::string &name) const {
 void SymbolTable::PrintStats() const {
     LOGF(SYMBOLS, "Symbol table statistics:\n");
     LOGF(SYMBOLS, "  Total symbols: %zu\n", GetSymbolCount());
+    LOGF(SYMBOLS, "  Enabled symbols: %zu\n", GetEnabledSymbolCount());
+    LOGF(SYMBOLS, "  Unique addresses with symbols: %zu\n", m_address_to_symbols.size());
 
     if (GetSymbolCount() > 0) {
         // Find address range
         uint16_t min_addr = 0xFFFF;
         uint16_t max_addr = 0;
-        for (const auto &pair : m_address_to_symbol) {
+        for (const auto &pair : m_address_to_symbols) {
             min_addr = std::min(min_addr, pair.first);
             max_addr = std::max(max_addr, pair.first);
         }
         LOGF(SYMBOLS, "  Address range: $%04X - $%04X\n", min_addr, max_addr);
+
+        // Show addresses with multiple symbols
+        size_t multi_symbol_addresses = 0;
+        for (const auto &pair : m_address_to_symbols) {
+            if (pair.second.size() > 1) {
+                multi_symbol_addresses++;
+            }
+        }
+        if (multi_symbol_addresses > 0) {
+            LOGF(SYMBOLS, "  Addresses with multiple symbols: %zu\n", multi_symbol_addresses);
+        }
     }
 }
 
@@ -217,4 +595,476 @@ std::string SymbolTable::TrimWhitespace(const std::string &str) const {
 bool SymbolTable::IsValidAddress(uint32_t addr) const {
     // BBC Micro has 16-bit address space
     return addr <= 0xFFFF;
+}
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+const SymbolTable::Symbol *SymbolTable::GetFirstEnabledSymbolAt(uint16_t address) const {
+    auto it = m_address_to_symbols.find(address);
+    if (it != m_address_to_symbols.end()) {
+        const std::vector<Symbol> &symbols = it->second;
+
+        // Search for the best symbol using precedence policy:
+        // 1. Prefer symbols from enabled groups
+        // 2. Among enabled groups, prefer lower group_id (first loaded group)
+        // 3. Within same group, prefer later loaded symbols (higher index in vector)
+
+        const Symbol *best_symbol = nullptr;
+        size_t best_group_id = SIZE_MAX;
+
+        for (const Symbol &symbol : symbols) {
+            if (symbol.group_id >= m_groups.size() || !m_groups[symbol.group_id].enabled) {
+                continue; // Skip disabled groups
+            }
+
+            // If this is from a higher priority group (lower group_id), use it
+            if (symbol.group_id < best_group_id) {
+                best_symbol = &symbol;
+                best_group_id = symbol.group_id;
+            }
+            // If same group as current best, prefer this one (later in file)
+            else if (symbol.group_id == best_group_id) {
+                best_symbol = &symbol;
+            }
+        }
+
+        return best_symbol;
+    }
+    return nullptr;
+}
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+// Group Management Methods
+
+size_t SymbolTable::AddGroup(const SymbolGroup &group) {
+    m_groups.push_back(group);
+    this->InvalidateCache();
+    return m_groups.size() - 1;
+}
+
+size_t SymbolTable::AddGroup(const std::string &name, const std::string &description, const std::string &file_path) {
+    SymbolGroup group(name, description, file_path);
+    return this->AddGroup(group);
+}
+
+bool SymbolTable::RemoveGroup(size_t group_id) {
+    if (group_id >= m_groups.size()) {
+        return false;
+    }
+
+    // Remove all symbols belonging to this group
+    this->ClearGroup(group_id);
+
+    // Remove the group
+    m_groups.erase(m_groups.begin() + static_cast<std::vector<SymbolGroup>::difference_type>(group_id));
+
+    // Update group IDs for all symbols with group_id > removed group
+    for (auto &addr_pair : m_address_to_symbols) {
+        for (Symbol &symbol : addr_pair.second) {
+            if (symbol.group_id > group_id) {
+                symbol.group_id--;
+            }
+        }
+    }
+
+    this->InvalidateCache();
+    return true;
+}
+
+void SymbolTable::EnableGroup(size_t group_id, bool enabled) {
+    if (group_id < m_groups.size()) {
+        m_groups[group_id].enabled = enabled;
+        this->InvalidateCache();
+    }
+}
+
+const SymbolTable::SymbolGroup *SymbolTable::GetGroup(size_t group_id) const {
+    if (group_id < m_groups.size()) {
+        return &m_groups[group_id];
+    }
+    return nullptr;
+}
+
+const std::vector<SymbolTable::SymbolGroup> &SymbolTable::GetAllGroups() const {
+    return m_groups;
+}
+
+void SymbolTable::ClearGroup(size_t group_id) {
+    // Remove all symbols belonging to this group
+    for (auto addr_it = m_address_to_symbols.begin(); addr_it != m_address_to_symbols.end();) {
+        std::vector<Symbol> &symbols = addr_it->second;
+
+        // Remove symbols from this group from the vector
+        symbols.erase(
+            std::remove_if(symbols.begin(), symbols.end(),
+                           [group_id](const Symbol &symbol) {
+                               return symbol.group_id == group_id;
+                           }),
+            symbols.end());
+
+        // If no symbols left at this address, remove the entry entirely
+        if (symbols.empty()) {
+            addr_it = m_address_to_symbols.erase(addr_it);
+        } else {
+            ++addr_it;
+        }
+    }
+
+    // Remove name mappings for symbols in this group
+    for (auto name_it = m_name_to_addresses.begin(); name_it != m_name_to_addresses.end();) {
+        uint16_t address = name_it->second;
+        const std::string &name = name_it->first;
+
+        // Check if this name/address combo still exists after group removal
+        bool found = false;
+        auto addr_symbols_it = m_address_to_symbols.find(address);
+        if (addr_symbols_it != m_address_to_symbols.end()) {
+            for (const Symbol &symbol : addr_symbols_it->second) {
+                if (symbol.name == name) {
+                    found = true;
+                    break;
+                }
+            }
+        }
+
+        if (!found) {
+            name_it = m_name_to_addresses.erase(name_it);
+        } else {
+            ++name_it;
+        }
+    }
+
+    this->InvalidateCache();
+}
+
+bool SymbolTable::MoveGroup(size_t from_index, size_t to_index) {
+    if (from_index >= m_groups.size() || to_index >= m_groups.size() || from_index == to_index) {
+        return false;
+    }
+
+    // All groups can now be moved - no special restrictions
+
+    // Create mapping from old position to new position before moving
+    std::vector<size_t> old_to_new_mapping(m_groups.size());
+
+    // Initialize identity mapping
+    for (size_t i = 0; i < m_groups.size(); ++i) {
+        old_to_new_mapping[i] = i;
+    }
+
+    // Calculate the new positions after the move
+    if (from_index < to_index) {
+        // Moving down: shift everything up between from+1 and to
+        for (size_t i = from_index + 1; i <= to_index; ++i) {
+            old_to_new_mapping[i] = i - 1;
+        }
+        old_to_new_mapping[from_index] = to_index;
+    } else {
+        // Moving up: shift everything down between to and from-1
+        for (size_t i = to_index; i < from_index; ++i) {
+            old_to_new_mapping[i] = i + 1;
+        }
+        old_to_new_mapping[from_index] = to_index;
+    }
+
+    // Move the group in the vector
+    SymbolGroup group_to_move = m_groups[from_index];
+    m_groups.erase(m_groups.begin() + static_cast<std::vector<SymbolGroup>::difference_type>(from_index));
+    m_groups.insert(m_groups.begin() + static_cast<std::vector<SymbolGroup>::difference_type>(to_index), group_to_move);
+
+    // Update all symbol group IDs using position-based mapping
+    for (auto &addr_pair : m_address_to_symbols) {
+        for (Symbol &symbol : addr_pair.second) {
+            if (symbol.group_id < old_to_new_mapping.size()) {
+                symbol.group_id = old_to_new_mapping[symbol.group_id];
+            }
+        }
+    }
+
+    this->InvalidateCache();
+    return true;
+}
+
+void SymbolTable::ReassignGroupIds(const std::vector<std::string> &original_group_names) {
+    // This method is deprecated - group reordering now uses position-based mapping
+    // instead of name-based mapping to handle duplicate group names correctly.
+    // Kept for backward compatibility but no longer used by MoveGroup.
+    (void)original_group_names; // Suppress unused parameter warning
+}
+
+void SymbolTable::ReassignGroupIds() {
+    // This method is deprecated - group reordering now uses position-based mapping
+    // built into MoveGroup() instead of separate name-based reassignment.
+    // Kept for backward compatibility but no longer used.
+}
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+// Group Metadata Editing Methods
+
+bool SymbolTable::SetGroupName(size_t group_id, const std::string &new_name) {
+    if (group_id >= m_groups.size()) {
+        return false;
+    }
+
+    std::string trimmed_name = new_name;
+    // Remove leading/trailing whitespace
+    size_t start = trimmed_name.find_first_not_of(" \t\n\r");
+    if (start == std::string::npos) {
+        trimmed_name = "Global"; // Default to Global if empty/whitespace only
+    } else {
+        size_t end = trimmed_name.find_last_not_of(" \t\n\r");
+        trimmed_name = trimmed_name.substr(start, end - start + 1);
+
+        if (trimmed_name.empty()) {
+            trimmed_name = "Global";
+        }
+    }
+
+    m_groups[group_id].name = trimmed_name;
+    LOGF(SYMBOLS, "Updated group %zu name to: %s\n", group_id, trimmed_name.c_str());
+    return true;
+}
+
+bool SymbolTable::SetGroupContexts(size_t group_id, const std::set<char> &new_contexts) {
+    if (group_id >= m_groups.size()) {
+        return false;
+    }
+
+    // Validate all contexts before setting
+    for (char context : new_contexts) {
+        if (!MemoryContexts::IsValidContext(context)) {
+            LOGF(SYMBOLS, "WARNING: Invalid memory context '%c' ignored in group %zu\n", context, group_id);
+            return false;
+        }
+    }
+
+    m_groups[group_id].memory_contexts = new_contexts;
+
+    // Invalidate cache since context changes affect symbol visibility
+    this->InvalidateCache();
+
+    if (new_contexts.empty()) {
+        LOGF(SYMBOLS, "Updated group %zu contexts to: universal (visible everywhere)\n", group_id);
+    } else {
+        LOGF(SYMBOLS, "Updated group %zu contexts to: ", group_id);
+        for (char c : new_contexts) {
+            LOGF(SYMBOLS, "'%c' ", c);
+        }
+        LOGF(SYMBOLS, "\n");
+    }
+
+    return true;
+}
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+// Context-Aware Symbol Lookup Methods
+
+const SymbolTable::Symbol *SymbolTable::GetSymbolForAddress(uint16_t address, char memory_context) const {
+    // Context-aware lookup with precedence policy
+    if (m_cache_dirty) {
+        this->RebuildCache();
+    }
+
+    auto context_it = m_context_to_address_cache.find(memory_context);
+    if (context_it != m_context_to_address_cache.end()) {
+        auto symbol_it = context_it->second.find(address);
+        if (symbol_it != context_it->second.end()) {
+            const std::vector<Symbol *> &symbols = symbol_it->second;
+            if (!symbols.empty()) {
+                // Apply precedence policy to find best symbol
+                const Symbol *best_symbol = nullptr;
+                size_t best_group_id = SIZE_MAX;
+
+                for (const Symbol *symbol : symbols) {
+                    // Skip disabled groups (should not happen due to cache, but be safe)
+                    if (symbol->group_id >= m_groups.size() || !m_groups[symbol->group_id].enabled) {
+                        continue;
+                    }
+
+                    // Prefer lower group_id (first loaded group)
+                    if (symbol->group_id < best_group_id) {
+                        best_symbol = symbol;
+                        best_group_id = symbol->group_id;
+                    }
+                    // Within same group, prefer later loaded symbol (CC65 style)
+                    else if (symbol->group_id == best_group_id) {
+                        best_symbol = symbol; // Later in cache = later loaded
+                    }
+                }
+
+                return best_symbol;
+            }
+        }
+    }
+    return nullptr;
+}
+
+uint16_t SymbolTable::GetAddressForSymbol(const std::string &name, char memory_context) const {
+    // Find ANY symbol with this name that is visible in the specified context
+    auto range = m_name_to_addresses.equal_range(name);
+    for (auto it = range.first; it != range.second; ++it) {
+        uint16_t address = it->second;
+
+        // Check if there's an enabled symbol with this name visible in this context
+        auto addr_it = m_address_to_symbols.find(address);
+        if (addr_it != m_address_to_symbols.end()) {
+            for (const Symbol &symbol : addr_it->second) {
+                if (symbol.name == name && this->IsSymbolVisibleInContext(symbol, memory_context)) {
+                    return address; // Found a symbol with this name in this context
+                }
+            }
+        }
+    }
+
+    return 0; // Symbol not visible in this context
+}
+
+bool SymbolTable::HasSymbolForAddress(uint16_t address, char memory_context) const {
+    return this->GetSymbolForAddress(address, memory_context) != nullptr;
+}
+
+bool SymbolTable::HasSymbol(const std::string &name, char memory_context) const {
+    return this->GetAddressForSymbol(name, memory_context) != 0;
+}
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+// Cache Management Methods
+
+void SymbolTable::InvalidateCache() const {
+    m_cache_dirty = true;
+}
+
+void SymbolTable::RebuildCache() const {
+    m_context_to_address_cache.clear();
+
+    for (auto &addr_pair : m_address_to_symbols) {
+        uint16_t address = addr_pair.first;
+        const std::vector<Symbol> &symbols = addr_pair.second;
+
+        for (const Symbol &symbol : symbols) {
+            // Skip disabled groups
+            if (symbol.group_id >= m_groups.size() || !m_groups[symbol.group_id].enabled) {
+                continue;
+            }
+
+            const SymbolGroup &group = m_groups[symbol.group_id];
+
+            // If group has specific contexts, add to those contexts
+            if (!group.memory_contexts.empty()) {
+                for (char context : group.memory_contexts) {
+                    m_context_to_address_cache[context][address].push_back(const_cast<Symbol *>(&symbol));
+                }
+            } else {
+                // Universal symbols: add to ALL common contexts
+                for (char context : MemoryContexts::UNIVERSAL_CACHE_CONTEXTS) {
+                    m_context_to_address_cache[context][address].push_back(const_cast<Symbol *>(&symbol));
+                }
+            }
+        }
+    }
+
+    m_cache_dirty = false;
+}
+
+bool SymbolTable::IsSymbolVisibleInContext(const Symbol &symbol, char memory_context) const {
+    if (symbol.group_id >= m_groups.size() || !m_groups[symbol.group_id].enabled) {
+        return false;
+    }
+
+    const SymbolGroup &group = m_groups[symbol.group_id];
+
+    // If group has no specific contexts, it's visible in ALL contexts (universal symbols)
+    if (group.memory_contexts.empty()) {
+        return true;
+    }
+
+    // Check if the symbol's group applies to this memory context
+    return group.memory_contexts.find(memory_context) != group.memory_contexts.end();
+}
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+// Persistence Methods
+
+nlohmann::json SymbolTable::SaveToJSON() const {
+    nlohmann::json j;
+
+    // Save groups (only essential fields, symbols are automatically reloaded from files)
+    j["groups"] = nlohmann::json::array();
+    for (const auto &group : m_groups) {
+        j["groups"].push_back(group.to_json());
+    }
+
+    return j;
+}
+
+bool SymbolTable::LoadFromJSON(const nlohmann::json &j) {
+    try {
+        if (j.contains("groups") && j["groups"].is_array()) {
+            m_groups.clear();
+            for (const auto &group_json : j["groups"]) {
+                SymbolGroup group;
+                group.from_json(group_json);
+                m_groups.push_back(group);
+            }
+
+            // Reload all groups from their source files
+            this->ReloadAllGroups();
+            return true;
+        }
+    } catch (const std::exception &e) {
+        LOGF(SYMBOLS, "ERROR: Failed to load symbol groups from JSON: %s\n", e.what());
+    }
+
+    return false;
+}
+
+void SymbolTable::ReloadAllGroups() {
+    // Clear all symbols but keep groups
+    m_address_to_symbols.clear();
+    m_name_to_addresses.clear();
+    this->InvalidateCache();
+
+    // Reload each group from its source file
+    for (size_t i = 0; i < m_groups.size(); ++i) {
+        const SymbolGroup &group = m_groups[i];
+
+        // Skip groups without source files (but always load disabled groups for counting)
+        if (group.file_path.empty()) {
+            continue;
+        }
+
+        // Check if file exists
+        std::ifstream test_file(group.file_path);
+        if (!test_file.is_open()) {
+            LOGF(SYMBOLS, "WARNING: Cannot reload group '%s' - file not found: %s\n",
+                 group.name.c_str(), group.file_path.c_str());
+            continue;
+        }
+        test_file.close();
+
+        // Read and parse the file
+        std::ifstream file(group.file_path);
+        std::ostringstream content_stream;
+        content_stream << file.rdbuf();
+        std::string content = content_stream.str();
+        file.close();
+
+        // Load symbols into this group (preserving enabled state)
+        LOGF(SYMBOLS, "Reloading group '%s' from: %s (enabled: %s)\n",
+             group.name.c_str(), group.file_path.c_str(), group.enabled ? "true" : "false");
+        this->LoadFromContent(content, i);
+    }
+
+    LOGF(SYMBOLS, "Reloaded %zu symbols across %zu groups\n", GetSymbolCount(), m_groups.size());
 }

--- a/src/b2/SymbolTable.h
+++ b/src/b2/SymbolTable.h
@@ -7,6 +7,10 @@
 #include <map>
 #include <string>
 #include <memory>
+#include <vector>
+#include <set>
+#include <unordered_map>
+#include "nlohmann_json_wrapper.h"
 
 //////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////
@@ -17,13 +21,108 @@ class SymbolTable {
         uint16_t address;
         std::string name;
         std::string comment; // optional - for future use
+        size_t group_id;     // which group this symbol belongs to
 
         Symbol()
-            : address(0) {
+            : address(0)
+            , group_id(0) {
         }
-        Symbol(uint16_t addr, const std::string &symbol_name)
+        Symbol(uint16_t addr, const std::string &symbol_name, size_t group = 0)
             : address(addr)
-            , name(symbol_name) {
+            , name(symbol_name)
+            , group_id(group) {
+        }
+    };
+
+    struct SymbolGroup {
+        std::string name;
+        std::string description;
+        std::string file_path; // source file for this group
+        bool enabled;
+        std::set<char> memory_contexts; // which memory contexts this group applies to (e.g. 'o', 'f', 'm')
+
+        SymbolGroup()
+            : enabled(true) {
+        }
+
+        SymbolGroup(const std::string &group_name, const std::string &desc = "", const std::string &path = "")
+            : name(group_name)
+            , description(desc)
+            , file_path(path)
+            , enabled(true) {
+        }
+
+        // Custom JSON serialization (save only essential fields)
+        nlohmann::json to_json() const {
+            nlohmann::json j{
+                {"file_path", file_path},
+                {"enabled", enabled},
+                {"name", name} // Save custom group name to preserve user choice
+            };
+
+            // Custom handling for std::set<char>
+            nlohmann::json contexts_array = nlohmann::json::array();
+            for (char c : memory_contexts) {
+                contexts_array.push_back(std::string(1, c));
+            }
+            j["memory_contexts"] = contexts_array;
+
+            return j;
+        }
+
+        void from_json(const nlohmann::json &j) {
+            j.at("file_path").get_to(file_path);
+            j.at("enabled").get_to(enabled);
+
+            // Custom handling for std::set<char>
+            memory_contexts.clear();
+            if (j.contains("memory_contexts") && j["memory_contexts"].is_array()) {
+                for (const auto &item : j["memory_contexts"]) {
+                    if (item.is_string()) {
+                        std::string str = item.get<std::string>();
+                        if (!str.empty()) {
+                            memory_contexts.insert(str[0]);
+                        }
+                    }
+                }
+            }
+
+            // Use saved name if available, otherwise auto-generate for backward compatibility
+            if (j.contains("name") && j["name"].is_string()) {
+                // Use saved custom group name
+                name = j["name"].get<std::string>();
+            } else {
+                // Auto-generate name from file_path for backward compatibility
+                if (file_path.empty()) {
+                    name = "Unknown";
+                } else {
+                    // Extract filename without extension for name
+                    std::string filename = file_path;
+                    size_t last_slash = filename.find_last_of("/\\");
+                    if (last_slash != std::string::npos) {
+                        filename = filename.substr(last_slash + 1);
+                    }
+                    size_t last_dot = filename.find_last_of('.');
+                    if (last_dot != std::string::npos) {
+                        filename = filename.substr(0, last_dot);
+                    }
+
+                    // Use "Global" for simple loads, filename for enhanced loads
+                    // (We'll detect this based on whether contexts are empty - simple loads have no contexts)
+                    if (memory_contexts.empty()) {
+                        name = "Global";
+                    } else {
+                        name = filename;
+                    }
+                }
+            }
+
+            // Always generate description from file path
+            if (file_path.empty()) {
+                description = "Unknown symbol group";
+            } else {
+                description = "Loaded from " + file_path;
+            }
         }
     };
 
@@ -32,31 +131,103 @@ class SymbolTable {
 
     // Core functionality
     void Clear();
-    bool LoadFromFile(const std::string &filepath);
+    bool LoadFromFile(const std::string &filepath, const std::string &group_name = "", const std::set<char> &memory_contexts = {});
     size_t GetSymbolCount() const;
+    size_t GetEnabledSymbolCount() const;
+    size_t GetSymbolCountForGroup(size_t group_id) const;
 
-    // Symbol lookup
+    // Group management
+    size_t AddGroup(const SymbolGroup &group);
+    size_t AddGroup(const std::string &name, const std::string &description = "", const std::string &file_path = "");
+    bool RemoveGroup(size_t group_id);
+    void EnableGroup(size_t group_id, bool enabled);
+    const SymbolGroup *GetGroup(size_t group_id) const;
+    const std::vector<SymbolGroup> &GetAllGroups() const;
+    void ClearGroup(size_t group_id);
+    bool MoveGroup(size_t from_index, size_t to_index);
+    void ReassignGroupIds();
+    void ReassignGroupIds(const std::vector<std::string> &original_group_names);
+
+    // Group metadata editing
+    bool SetGroupName(size_t group_id, const std::string &new_name);
+    bool SetGroupContexts(size_t group_id, const std::set<char> &new_contexts);
+
+    // Context-aware symbol lookup (symbols without explicit contexts are universal)
+    const Symbol *GetSymbolForAddress(uint16_t address, char memory_context) const;
+    uint16_t GetAddressForSymbol(const std::string &name, char memory_context) const;
+    bool HasSymbolForAddress(uint16_t address, char memory_context) const;
+    bool HasSymbol(const std::string &name, char memory_context) const;
+
+    // Legacy lookup methods (for backwards compatibility)
+    // GetSymbolForAddress uses symbol precedence policy for DISPLAY:
+    //   1. Prefer symbols from enabled groups
+    //   2. Among enabled groups, prefer first loaded group (lower group_id)
+    //   3. Within same group, prefer later loaded symbols (e.g., CC65 "_main" over "__MY_RAM_START__")
+    // GetAddressForSymbol finds ANY symbol with the given name (ignores display precedence)
     const Symbol *GetSymbolForAddress(uint16_t address) const;
     uint16_t GetAddressForSymbol(const std::string &name) const;
     bool HasSymbolForAddress(uint16_t address) const;
     bool HasSymbol(const std::string &name) const;
 
-    // Format-specific loaders
-    bool LoadViceFormat(const std::string &content);
+    // Base class for symbol file parsers
+    class SymbolParser {
+      public:
+        virtual ~SymbolParser() = default;
+        virtual std::string GetFormatName() const = 0;
+        virtual bool MatchesLine(const std::string &line) const = 0;
+        virtual bool ParseContent(const std::string &content, size_t group_id, SymbolTable *table) = 0;
+    };
+
+    // Parser registry system
+    class SymbolParserRegistry {
+      public:
+        static void RegisterParser(std::unique_ptr<SymbolParser> parser);
+        static const std::vector<std::unique_ptr<SymbolParser>> &GetParsers();
+        static void InitializeBuiltinParsers(); // Initialize VICE and ACME parsers
+
+      private:
+        static std::vector<std::unique_ptr<SymbolParser>> s_parsers;
+    };
+
+    // Format detection and loading
+    SymbolParser *DetectBestParser(const std::string &content);
+    bool LoadFromContent(const std::string &content, size_t group_id);
+
+    // Legacy format-specific loaders (now used by parser implementations)
+    bool LoadViceFormat(const std::string &content, size_t group_id = 0);
+    bool LoadAcmeFormat(const std::string &content, size_t group_id = 0);
+
+    // Persistence support
+    nlohmann::json SaveToJSON() const;
+    bool LoadFromJSON(const nlohmann::json &j);
+    void ReloadAllGroups(); // Reload all groups from their source files
 
     // Debugging/utility
     void PrintStats() const;
 
   private:
-    std::map<uint16_t, Symbol> m_address_to_symbol;
-    std::map<std::string, uint16_t> m_name_to_address;
+    std::vector<SymbolGroup> m_groups;
+    std::map<uint16_t, std::vector<Symbol>> m_address_to_symbols; // Multiple symbols per address
+    std::multimap<std::string, uint16_t> m_name_to_addresses;     // Multiple addresses per name
+
+    // Context-aware lookup maps for performance
+    // Maps memory_context -> address -> vector of symbols
+    mutable std::unordered_map<char, std::map<uint16_t, std::vector<Symbol *>>> m_context_to_address_cache;
+    mutable bool m_cache_dirty;
 
     // Helper methods
     std::string TrimWhitespace(const std::string &str) const;
     bool IsValidAddress(uint32_t addr) const;
+    void InvalidateCache() const;
+    void RebuildCache() const;
+    bool IsSymbolVisibleInContext(const Symbol &symbol, char memory_context) const;
+    const Symbol *GetFirstEnabledSymbolAt(uint16_t address) const;
 };
 
 //////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////
+
+// Custom JSON serialization for SymbolGroup (save only essential fields)
+// name and description are auto-generated on load
 
 #endif

--- a/src/b2/debugger.cpp
+++ b/src/b2/debugger.cpp
@@ -1779,7 +1779,12 @@ class DisassemblyDebugWindow : public DebugUIWithPersistentData<DisassemblyDebug
             if (m_show_labels) {
                 // Check for symbol at this address when labels are enabled
                 const SymbolTable &symbol_table = m_beeb_window->GetSymbolTable();
-                const SymbolTable::Symbol *symbol = symbol_table.GetSymbolForAddress(line_addr.w);
+
+                // Get memory context from debug big page metadata (same as instruction operands)
+                char memory_context = line_dbp->bp.metadata->minimal_codes[0];
+
+                // Use context-aware symbol lookup
+                const SymbolTable::Symbol *symbol = symbol_table.GetSymbolForAddress(line_addr.w, memory_context);
 
                 ImGui::SameLine();
                 ImGui::Text("  "); // Add some spacing
@@ -2101,11 +2106,38 @@ class DisassemblyDebugWindow : public DebugUIWithPersistentData<DisassemblyDebug
         this->AddWord(IND_PREFIX, addr.w, mos, "");
     }
 
-    void AddWord(const char *prefix, uint16_t w, bool mos, const char *suffix) {
-        const DebugBigPage *dbp = this->GetDebugBigPageForAddress({w}, mos);
+    void AddAddress(const char *prefix, uint16_t addr, bool mos, const char *suffix, const char *hex_format) {
+        const DebugBigPage *dbp = this->GetDebugBigPageForAddress({addr}, mos);
 
         char label[100];
-        snprintf(label, sizeof label, "%s%04x%c%s", g_hex, w, ADDRESS_SUFFIX_SEPARATOR, dbp->bp.metadata->minimal_codes);
+
+        // Check if we should use symbols instead of hex addresses
+        if (m_show_labels) {
+            const SymbolTable &symbol_table = m_beeb_window->GetSymbolTable();
+
+            // Get the memory context from the debug big page metadata
+            char memory_context = dbp->bp.metadata->minimal_codes[0];
+
+            // Use context-aware symbol lookup
+            const SymbolTable::Symbol *symbol = symbol_table.GetSymbolForAddress(addr, memory_context);
+
+            if (symbol) {
+                // Use symbol name instead of hex address
+                snprintf(label, sizeof label, "%s%c%s", symbol->name.c_str(), ADDRESS_SUFFIX_SEPARATOR, dbp->bp.metadata->minimal_codes);
+            } else {
+                // No symbol found, use hex as fallback
+                snprintf(label, sizeof label, hex_format, g_hex, addr, ADDRESS_SUFFIX_SEPARATOR, dbp->bp.metadata->minimal_codes);
+            }
+        } else {
+            // Labels disabled, use hex address
+            snprintf(label, sizeof label, hex_format, g_hex, addr, ADDRESS_SUFFIX_SEPARATOR, dbp->bp.metadata->minimal_codes);
+        }
+
+        this->DoClickableAddress(prefix, label, suffix, dbp, {addr});
+    }
+
+    void AddWord(const char *prefix, uint16_t w, bool mos, const char *suffix) {
+        this->AddAddress(prefix, w, mos, suffix, "%s%04x%c%s");
 
         //static_assert(sizeof dbp->bp.metadata->codes == 3);
         //char label[] = {
@@ -2119,15 +2151,10 @@ class DisassemblyDebugWindow : public DebugUIWithPersistentData<DisassemblyDebug
         //    HEX_CHARS_LC[w & 15],
         //    0,
         //};
-
-        this->DoClickableAddress(prefix, label, suffix, dbp, {w});
     }
 
     void AddByte(const char *prefix, uint8_t value, bool mos, const char *suffix) {
-        const DebugBigPage *dbp = this->GetDebugBigPageForAddress({value}, mos);
-
-        char label[100];
-        snprintf(label, sizeof label, "%s%02x%c%s", g_hex, value, ADDRESS_SUFFIX_SEPARATOR, dbp->bp.metadata->minimal_codes);
+        this->AddAddress(prefix, value, mos, suffix, "%s%02x%c%s");
 
         //static_assert(sizeof dbp->bp.metadata->codes == 3);
         //char label[] = {
@@ -2139,8 +2166,6 @@ class DisassemblyDebugWindow : public DebugUIWithPersistentData<DisassemblyDebug
         //    HEX_CHARS_LC[value & 15],
         //    0,
         //};
-
-        this->DoClickableAddress(prefix, label, suffix, dbp, {value});
     }
 
     void DoClickableAddress(const char *prefix,

--- a/src/b2/debugger.h
+++ b/src/b2/debugger.h
@@ -45,6 +45,7 @@ std::unique_ptr<SettingsUI> CreateDiskDriveDebugWindow(BeebWindow *beeb_window);
 std::unique_ptr<SettingsUI> CreateHardDiskDebugWindow(BeebWindow *beeb_window);
 std::unique_ptr<SettingsUI> CreateSCSIDebugWindow(BeebWindow *beeb_window);
 std::unique_ptr<SettingsUI> CreateSerialDebugWindow(BeebWindow *beeb_window);
+std::unique_ptr<SettingsUI> CreateSymbolGroupManagementWindow(BeebWindow *beeb_window);
 
 //////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////

--- a/src/b2/memory_contexts.cpp
+++ b/src/b2/memory_contexts.cpp
@@ -1,0 +1,13 @@
+#include "memory_contexts.h"
+#include <algorithm>
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+namespace MemoryContexts {
+
+    bool IsValidContext(char c) {
+        return std::find(ALL_CONTEXTS.begin(), ALL_CONTEXTS.end(), c) != ALL_CONTEXTS.end();
+    }
+
+} // namespace MemoryContexts

--- a/src/b2/memory_contexts.h
+++ b/src/b2/memory_contexts.h
@@ -1,0 +1,80 @@
+#ifndef MEMORY_CONTEXTS_H
+#define MEMORY_CONTEXTS_H
+
+#include <array>
+#include <string>
+#include <set>
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+namespace MemoryContexts {
+
+    // All valid BBC Micro memory contexts (40 total)
+    constexpr std::array<char, 40> ALL_CONTEXTS = {
+        // Core contexts (8)
+        'm', 'o', 's', 'n', 'h', 'i', 'p', 'r',
+        // Standard ROM banks 0-15 (16)
+        '0', '1', '2', '3', '4', '5', '6', '7',
+        '8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
+        // ROM mapper contexts A-P (16)
+        'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
+        'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P'};
+
+    // Universal contexts (common ones for cache optimization)
+    constexpr std::array<char, 22> UNIVERSAL_CACHE_CONTEXTS = {
+        'm', 'o', '0', '1', '2', '3', '4', '5', '6', '7',
+        '8', '9', 'a', 'b', 'c', 'd', 'e', 'f', 's', 'n', 'h', 'i'};
+
+    // Context categories for UI organization
+    struct ContextInfo {
+        char context;
+        const char *description;
+    };
+
+    struct ContextGroup {
+        const char *name;
+        std::array<ContextInfo, 16> contexts; // Max 16 contexts per group
+        size_t count;
+        bool collapsible;
+    };
+
+    // Organized context groups for UI display
+    constexpr std::array<ContextGroup, 6> CONTEXT_GROUPS = {{{"Common",
+                                                              {{{'m', "Main RAM"},
+                                                                {'o', "OS ROM (MOS)"}}},
+                                                              2,
+                                                              false},
+                                                             {"ROM Banks 0-15",
+                                                              {{{'0', ""}, {'1', ""}, {'2', ""}, {'3', ""}, {'4', ""}, {'5', ""}, {'6', ""}, {'7', ""}, {'8', ""}, {'9', ""}, {'a', ""}, {'b', ""}, {'c', ""}, {'d', ""}, {'e', ""}, {'f', ""}}},
+                                                              16,
+                                                              false},
+                                                             {"Shadow/Extra RAM",
+                                                              {{{'s', "Shadow RAM"},
+                                                                {'n', "ANDY (extra RAM)"},
+                                                                {'h', "HAZEL (Master)"}}},
+                                                              3,
+                                                              true},
+                                                             {"Parasite (Second Processor)",
+                                                              {{{'p', "Parasite RAM"},
+                                                                {'r', "Parasite boot ROM"}}},
+                                                              2,
+                                                              true},
+                                                             {"ROM Mappers (A-P)",
+                                                              {{{'A', ""}, {'B', ""}, {'C', ""}, {'D', ""}, {'E', ""}, {'F', ""}, {'G', ""}, {'H', ""}, {'I', ""}, {'J', ""}, {'K', ""}, {'L', ""}, {'M', ""}, {'N', ""}, {'O', ""}, {'P', ""}}},
+                                                              16,
+                                                              true},
+                                                             {"Other",
+                                                              {{{'i', "I/O area"}}},
+                                                              1,
+                                                              true}}};
+
+    // Context validation and utility functions
+    bool IsValidContext(char c);
+
+} // namespace MemoryContexts
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+#endif // MEMORY_CONTEXTS_H

--- a/src/b2/symbol_ui_constants.h
+++ b/src/b2/symbol_ui_constants.h
@@ -1,0 +1,56 @@
+#ifndef SYMBOL_UI_CONSTANTS_H
+#define SYMBOL_UI_CONSTANTS_H
+
+#include <cstddef> // for size_t
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+namespace SymbolUI {
+
+    // Symbol Loading Window dimensions
+    constexpr float LOADING_WINDOW_WIDTH_BASIC = 500.0f;
+    constexpr float LOADING_WINDOW_HEIGHT_BASIC = 200.0f;
+    constexpr float LOADING_WINDOW_WIDTH_ADVANCED = 600.0f;
+    constexpr float LOADING_WINDOW_HEIGHT_ADVANCED = 500.0f;
+
+    // Group Management Window dimensions
+    constexpr float MANAGEMENT_WINDOW_WIDTH = 750.0f;
+    constexpr float MANAGEMENT_WINDOW_HEIGHT = 500.0f;
+    constexpr float MANAGEMENT_TABLE_RESERVED_HEIGHT = 100.0f; // Space for buttons below table
+
+    // Context Edit Modal dimensions
+    constexpr float CONTEXT_MODAL_WIDTH = 600.0f;
+    constexpr float CONTEXT_MODAL_HEIGHT = 400.0f;
+
+    // Table column widths
+    constexpr float COL_INDEX_WIDTH = 20.0f;
+    constexpr float COL_SELECT_WIDTH = 15.0f;
+    constexpr float COL_MOVE_WIDTH = 60.0f;
+    constexpr float COL_ENABLED_WIDTH = 80.0f;
+    constexpr float COL_GROUP_NAME_WIDTH = 120.0f;
+    constexpr float COL_COUNT_WIDTH = 40.0f;
+    constexpr float COL_CONTEXTS_WIDTH = 100.0f;
+    constexpr float COL_SOURCE_FILE_WIDTH = 220.0f;
+
+    // UI Layout constants
+    constexpr int CONTEXTS_PER_ROW = 8;          // For ROM banks display
+    constexpr int CONTEXTS_PER_TOOLTIP_LINE = 6; // For tooltip formatting
+    constexpr int MAX_GROUP_NAME_LENGTH = 255;
+    constexpr size_t MAX_FILE_PATH_LENGTH = 511; // -1 for null terminator = 512
+
+    // Help text sizing
+    constexpr float CONTEXT_HELP_LINES = 11.0f; // Number of lines in context help
+
+    // UI colors (ImGui RGBA format)
+    constexpr unsigned int SELECTED_ROW_COLOR = 0x28C8DC46; // IM_COL32(70, 140, 200, 40)
+
+    // Button spacing
+    constexpr float ARROW_BUTTON_SPACING = 2.0f;
+
+} // namespace SymbolUI
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+#endif // SYMBOL_UI_CONSTANTS_H

--- a/symbol_architecture.md
+++ b/symbol_architecture.md
@@ -1,0 +1,284 @@
+# Symbol System Architecture
+
+## Overview
+
+This document describes the enhanced symbol system implemented for the b2 BBC Micro emulator debugger. The system supports multiple symbols per address, context-aware symbol lookup, and efficient caching for real-time disassembly display.
+
+## Core Problem Solved
+
+The BBC Micro has complex memory mapping with different ROM banks, shadow RAM, and main RAM. A single address (e.g., `0x8000`) might contain different symbols depending on the memory context:
+- `_basic_start` in ROM bank F  
+- `_user_code` in main RAM
+- `_os_routine` in OS ROM
+
+Additionally, tools like CC65 generate multiple symbols at the same address (e.g., `__SEGMENT_START__` followed by `_main`), where the later symbol is typically more meaningful for debugging.
+
+---
+
+## 1. Multiple Symbols System
+
+### Data Structures
+
+The system uses three primary data structures to support multiple symbols per address:
+
+#### Primary Storage
+Maps each memory address to a vector containing ALL symbols at that address. This allows multiple symbols from different sources to coexist at the same location.
+
+#### Name Lookup
+A multimap that allows looking up addresses by symbol name. Supports multiple addresses per name for cases where the same symbol name appears in different contexts.
+
+#### Context Cache
+A two-level cache system where the first level is memory context (like 'm' for main RAM, 'f' for ROM bank F) and the second level maps addresses to symbols visible in that context. This enables fast context-aware lookups during real-time disassembly.
+
+### Symbol Precedence Policy
+
+When multiple symbols exist at the same address, the system applies a three-tier precedence policy:
+
+1. **Enabled groups first**: Disabled groups are ignored
+2. **Lower group_id wins**: First-loaded group takes precedence  
+3. **Later symbols within group win**: CC65 style - `_main` overrides `__SEGMENT_START__`
+
+### Examples
+
+**CC65 Style (Same Group)**:
+At address 0x8023 in Group 0, if `__SEGMENT_START__` is loaded first and `_basic_warm_start` is loaded later, `_basic_warm_start` wins and will be displayed.
+
+**Multiple Groups**:
+At address 0x3000, if `_main` is in Group 0 and `_alt_main` is in Group 1 (both enabled), `_main` wins because it has the lower group ID.
+
+---
+
+## 2. Group System
+
+### Group Concept
+
+The group system has two distinct levels:
+
+**Group Names** (UI Organization):
+Display labels like "MOS Symbols" or "User Code" used for organizing entries in the Debug menu. Multiple file entries can share the same group name for bulk operations.
+
+**Individual Entries** (Technical Groups):  
+Each loaded symbol file creates a separate entry with its own unique properties: file path, enabled state, memory contexts, and symbol data. Each entry gets its own group ID regardless of whether it shares a display name with other entries.
+
+### Entry Assignment Logic
+
+When loading symbols:
+
+1. **Always create a new entry**: Each loaded file gets a distinct entry in the symbol table
+2. **Group ID assignment**: Each entry gets the next available group ID (index in the entries vector)  
+3. **Group name assignment**: 
+   - Basic loading: If no advanced options are used, the group name defaults to "Global"
+   - Advanced options: Custom name provided by user, can be the same as existing group names.
+4. **Memory contexts**: Applied individually to each entry, not to the group name
+
+### Group Behavior Examples
+
+**Different Group Names**:
+Each file with a different group name appears as a separate line in both the Debug menu and Group Management window.
+
+**Same Group Names** (UI grouping):
+Multiple files with the same group name appear as separate entries in Group Management but are consolidated in the Debug menu for bulk enable/disable operations.
+
+---
+
+## 3. Configuration Persistence  
+
+### Selective Saving Strategy
+
+The system saves only essential user-configurable fields to the configuration file, while auto-generating derived fields on load.
+
+#### Saved Fields (Per Entry)
+- File path to the symbol file
+- Enabled/disabled state  
+- Memory contexts for this specific entry
+- Custom group name (if provided via advanced options)
+
+#### Auto-Generated Fields (Derived)
+- **Group name**: Generated from filename for basic loads, preserved when advanced options specify custom names
+- **Description**: Auto-generated description based on file path
+
+#### Benefits
+- **Smaller config files**: Significant size reduction by not storing derived data
+- **Self-healing**: Names and descriptions regenerate if files move or change
+- **Consistency**: Uniform behavior regardless of how symbols were loaded
+
+#### Basic vs Advanced Options Detection
+Basic loads (those without memory contexts specified) get generic names, while loads using advanced options preserve custom group names provided by the user.
+
+---
+
+## 4. Memory Context System
+
+### Supported Contexts (38 Total)
+
+The BBC Micro emulator now supports 38 different memory contexts:
+
+#### Core Contexts
+- **'m'**: Main RAM
+- **'o'**: OS ROM (MOS)
+- **'s'**: Shadow RAM  
+- **'n'**: ANDY (extra RAM)
+- **'h'**: HAZEL (Master extra RAM)
+- **'i'**: I/O area
+
+#### Standard ROM Banks
+- **'0'-'f'**: ROM banks 0-15 (16 contexts)
+
+#### Parasite (Second Processor)
+- **'p'**: Parasite RAM
+- **'r'**: Parasite boot ROM
+
+#### ROM Mappers
+- **'A'-'P'**: ROM mapper regions 0-15 (16 additional contexts)
+
+### Universal vs Context-Specific Symbols
+
+**Universal Symbols** (loaded without explicit context):
+Visible in ALL memory contexts. These symbols appear regardless of which ROM bank or RAM configuration is active.
+
+**Context-Specific Symbols**:
+Only visible in their designated memory contexts. For example, a symbol marked for context 'f' only appears when ROM bank F is active.
+
+### Context vs Precedence
+
+Memory contexts affect **ELIGIBILITY**, not **PRECEDENCE RANKING**:
+
+1. **Context Filtering**: Determines which symbols are visible in the requested context
+2. **Precedence Ranking**: Among visible symbols, determines which is best (based on group_id and load order)
+
+Universal symbols have equal precedence to context-specific symbols - they're not penalized for being universal.
+
+---
+
+## 5. Cache System
+
+### Cache Purpose
+
+The cache system pre-computes which symbols are visible in each memory context, enabling immediate context-aware lookups during real-time disassembly without having to filter symbols on every request.
+
+### Cache Structure
+
+The cache is organized as a two-level map where the first level is memory context character and the second level maps addresses to vectors of symbol pointers visible in that context.
+
+### Cache Rebuilding
+
+The cache uses **lazy rebuilding**:
+1. Mark cache dirty when symbols change
+2. Rebuild only when needed for lookup
+3. Store pointers to symbols to avoid data duplication
+
+**Universal Symbol Caching**:
+Universal symbols (those without explicit contexts) are added to ALL 38 memory contexts during cache rebuild.
+
+**Context-Specific Symbol Caching**:
+Context-specific symbols are only added to their designated contexts during cache rebuild.
+
+---
+
+## 6. User Interface Integration
+
+### Symbol Group Management Window
+
+A comprehensive management interface that allows users to:
+- View all loaded symbol groups in precedence order
+- Enable/disable groups individually
+- Reorder groups to change precedence
+- Edit group names inline
+- Edit memory contexts via modal popup
+- Delete groups and their symbols
+- View symbol counts per group
+
+The window persists its open state between application sessions and integrates with the main popup system.
+
+### Unified Symbol Loading Dialog
+
+A single loading dialog with expandable advanced options that supports:
+- Basic loading (universal context, auto-generated group names)
+- Advanced options (custom contexts, custom group names)
+- Memory context selection with organized UI (common contexts first, advanced contexts in collapsible sections)
+
+### Context Selection UI
+
+A shared helper system for selecting memory contexts that organizes the 38 contexts into logical groups:
+- **Most common**: Main RAM ('m') and OS ROM ('o') 
+- **Standard ROM banks**: '0'-'f' in two rows
+- **Shadow/Extra RAM**: Collapsible section for 's', 'n', 'h'
+- **Parasite**: Collapsible section for 'p', 'r'  
+- **ROM Mappers**: Collapsible section for 'A'-'P'
+- **Other**: Collapsible section for 'i'
+
+### Debug Menu Integration
+
+The system provides a two-tier approach:
+
+**Debug Menu**: Groups entries by display name (e.g., "MOS Symbols") for bulk enable/disable operations. If some entries sharing a name are enabled and others disabled, a tristate checkbox appears.
+
+**Group Management Window**: Shows every individual entry separately, each with its own row, contexts, and controls. Multiple entries can have the same display name but remain distinct for granular management.
+
+---
+
+## 7. Lookup Flow Sequence
+
+The symbol lookup process follows this sequence:
+
+1. Disassembly window requests symbol at specific address in specific context
+2. System checks if cache needs rebuilding
+3. If cache is dirty, rebuild by filtering all symbols into appropriate contexts
+4. Look up pre-filtered symbols from cache for the requested context and address
+5. Apply precedence policy to determine best symbol among visible candidates
+6. Return winning symbol for display
+7. Disassembly shows symbolic name instead of raw address
+
+---
+
+## 8. Key Behavioral Differences
+
+### Display Lookups vs Name Lookups
+
+**Display Lookup**:
+Uses precedence policy to find the "best" symbol for display in disassembly windows. Shows the most relevant symbol to the user based on group precedence.
+
+**Name Lookup**:  
+Finds any enabled symbol with the requested name, regardless of display precedence. This ensures all loaded symbols remain accessible via the address bar, even when precedence rules favor displaying different symbols.
+
+### Context Display Improvements
+
+When showing multiple contexts in tooltips or debug information, contexts are now displayed in groups of 6 per line with proper formatting and total counts, making large context lists much more readable.
+
+---
+
+## 9. Performance Characteristics
+
+- **Symbol Loading**: Fast (no immediate cache rebuild required)
+- **First Lookup After Load**: Slower (triggers cache rebuild)  
+- **Subsequent Lookups**: Very fast (cached context filtering + precedence)
+- **Memory Usage**: Efficient (pointer-based cache, no symbol duplication)
+- **Scalability**: Handles thousands of symbols across dozens of groups without performance degradation
+
+---
+
+## 10. Integration Points
+
+The symbol system integrates seamlessly with:
+- **Disassembly Window**: Real-time instruction symbol display with context awareness
+- **Address Bar**: Symbol name to address navigation
+- **Symbol Loading UI**: Both basic and advanced loading workflows
+- **Group Management**: Enable/disable, reorder, and reload functionality
+- **Configuration Persistence**: Automatic save/restore of symbol groups and preferences
+- **Debug Menu**: Bulk operations on groups with same display name
+
+---
+
+## Conclusion
+
+This symbol system architecture provides:
+- ✅ **Multiple symbols per address** from different sources with clear precedence
+- ✅ **Context-aware display** supporting all 38 BBC Micro memory contexts
+- ✅ **Efficient caching** with lazy rebuilds for optimal performance
+- ✅ **Comprehensive management UI** for organizing and controlling symbol groups  
+- ✅ **Universal and context-specific** symbol support with equal precedence treatment
+- ✅ **Scalable design** suitable for complex debugging scenarios with many symbol files
+- ✅ **Persistent configuration** that survives application restarts
+- ✅ **Clean, maintainable codebase** with shared UI components and helper functions
+
+The system successfully handles the complexity of BBC Micro memory mapping while providing intuitive symbol management and high-performance real-time disassembly display. Users can load symbols from multiple sources, organize them into logical groups, and have confidence that the most relevant symbols will be displayed in each memory context.


### PR DESCRIPTION
This has a lot of changes I've been working on for the last few days.

It tries to address the b2_notes.org points in Debugger symbols section.

Here's a summary of the work:

## Symbol System Changes

• **Multiple symbols per address**: System now supports multiple symbols from different files at the same address with precedence rules (group ID, then load order)

• **Memory context support**: Added support for 38 BBC Micro memory contexts (main RAM, OS ROM, ROM banks 0-f, shadow RAM, parasite, ROM mappers A-P)

• **Context-aware symbol display**: Symbols now show correctly based on active ROM bank/memory configuration in debugger

• **Group management system**: Each loaded symbol file creates a manageable entry with individual enable/disable, reordering, and deletion

• **Unified loading dialog**: Combined simple and advanced loading into single dialog with collapsible advanced options for group names and contexts

• **Symbol Group Management window**: Added dedicated window for viewing, organizing, and managing all loaded symbol files

• **Configuration persistence**: Symbol files, groups, and settings now save/restore automatically across application restarts

• **Multi-format support**: Added ACME format support alongside VICE, with extensible parser registry for future formats

• **Two-tier group display**: Debug menu groups by display name for bulk operations, management window shows individual entries

• **Performance caching**: Implemented context-aware symbol cache for fast real-time disassembly lookup