### PR TITLE
Gtk4 async

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /build/
 /etc/b2_tests/[Zz]/
 /dependencies/ProcessorTests/
+.vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,8 +308,9 @@ endif()
 ##########################################################################
 
 if(LINUX)
-  find_package(GTK2 2.0 REQUIRED gtk)
-  message(STATUS "GTK2 include folder: " ${GTK2_INCLUDE_DIRS})
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(GTK4 REQUIRED gtk4)
+  message(STATUS "GTK4 include folder: " ${GTK4_INCLUDE_DIRS})
 endif()
 
 ##########################################################################

--- a/src/b2/BeebWindow.cpp
+++ b/src/b2/BeebWindow.cpp
@@ -685,6 +685,7 @@ BeebWindow::BeebWindow(BeebWindowInitArguments init_arguments)
     , m_symbol_table(std::make_unique<SymbolTable>())
 #endif
 {
+
     m_name = m_init_arguments.name;
 
     m_message_list = std::make_shared<MessageList>("BeebWindow");
@@ -1046,23 +1047,29 @@ class FileMenuItem {
 
     // details of the disk type, if the new disk option was chosen.
     const Disc *new_disc_type = nullptr;
-    std::vector<uint8_t> new_disc_data;
+    std::shared_ptr<std::vector<uint8_t>> new_disc_data;
 
     explicit FileMenuItem(SelectorDialog *new_dialog,
                           SelectorDialog *open_dialog,
                           const char *new_title,
                           const char *open_title,
                           const char *recent_title,
-                          Messages *msgs) {
+                          Messages *msgs,
+                          BeebWindow *beeb_window) {
         //bool recent_enabled=true;
 
         ImGuiIDPusher id_pusher(open_title);
 
         if (ImGui::MenuItem(open_title)) {
-            if (open_dialog->Open(&this->path)) {
-                m_used_dialog = open_dialog;
-                this->load = true;
-            }
+            // Use async callback with persistent state
+            open_dialog->OpenWithCallback([beeb_window, open_dialog](const std::string& path) {
+                if (!path.empty()) {
+                    // Store result in persistent state
+                    beeb_window->m_pending_file_menu_item.path = path;
+                    beeb_window->m_pending_file_menu_item.used_dialog = open_dialog;
+                    beeb_window->m_pending_file_menu_item.load = true;
+                }
+            });
         }
 
         if (ImGui::BeginMenu(new_title)) {
@@ -1070,14 +1077,16 @@ class FileMenuItem {
                                    BLANK_DFS_DISCS,
                                    NUM_BLANK_DFS_DISCS,
                                    false,
-                                   msgs);
+                                   msgs,
+                                   beeb_window);
             ImGui::Separator();
 
             this->DoBlankDiscsMenu(new_dialog,
                                    BLANK_ADFS_DISCS,
                                    NUM_BLANK_ADFS_DISCS,
                                    true,
-                                   msgs);
+                                   msgs,
+                                   beeb_window);
 
             ImGui::EndMenu();
         }
@@ -1093,6 +1102,20 @@ class FileMenuItem {
         }
     }
 
+    // Check for pending async results and apply them to this instance
+    void CheckPendingResult(BeebWindow *beeb_window) {
+        if (beeb_window->m_pending_file_menu_item.load) {
+            this->path = beeb_window->m_pending_file_menu_item.path;
+            this->new_disc_type = beeb_window->m_pending_file_menu_item.new_disc_type;
+            this->new_disc_data = beeb_window->m_pending_file_menu_item.new_disc_data; // shared_ptr assignment (no copy)
+            m_used_dialog = beeb_window->m_pending_file_menu_item.used_dialog;
+            this->load = true;
+
+            // Clear the pending state
+            beeb_window->m_pending_file_menu_item = BeebWindow::FileMenuItemState{};
+        }
+    }
+
   protected:
   private:
     SelectorDialog *m_used_dialog = nullptr;
@@ -1101,26 +1124,42 @@ class FileMenuItem {
                           const Disc *discs,
                           size_t num_discs,
                           bool adfs,
-                          Messages *msgs) {
+                          Messages *msgs,
+                          BeebWindow *beeb_window) {
         for (size_t i = 0; i < num_discs; ++i) {
             const Disc *disc = &discs[i];
 
             if (ImGui::MenuItem(disc->name.c_str())) {
                 std::string src_path = disc->GetAssetPath();
 
-                if (!LoadFile(&this->new_disc_data, src_path, msgs)) {
+                // Load data into a temporary vector first
+                std::vector<uint8_t> temp_disc_data;
+                if (!LoadFile(&temp_disc_data, src_path, msgs)) {
                     return;
                 }
 
                 if (adfs) {
-                    RandomizeADFSDiskIdentifier(&this->new_disc_data);
+                    RandomizeADFSDiskIdentifier(&temp_disc_data);
                 }
 
-                if (dialog->Open(&this->path)) {
-                    this->new_disc_type = disc;
-                    m_used_dialog = dialog;
-                    this->load = true;
-                }
+                // Use async callback with persistent state
+                // Use shared_ptr to avoid copying large disc data
+                auto disc_data_shared = std::make_shared<std::vector<uint8_t>>(std::move(temp_disc_data));
+                dialog->OpenWithCallback([beeb_window, dialog, disc, disc_data_shared](const std::string& path) {
+                    if (!path.empty()) {
+                        if (SaveFile(*disc_data_shared, path, &beeb_window->m_msg)) {
+                            // Store result in persistent state for the FileMenuItem to pick up
+                            beeb_window->m_pending_file_menu_item.path = path;
+                            beeb_window->m_pending_file_menu_item.new_disc_type = disc;
+                            beeb_window->m_pending_file_menu_item.new_disc_data = disc_data_shared; // Store shared_ptr directly
+                            beeb_window->m_pending_file_menu_item.used_dialog = dialog;
+                            beeb_window->m_pending_file_menu_item.load = true;
+
+                            // Update recent paths
+                            dialog->AddLastPathToRecentPaths(path);
+                        }
+                    }
+                });
             }
         }
     }
@@ -1529,14 +1568,21 @@ void BeebWindow::DoCommands(bool *close_window) {
     if (m_cst.WasActioned(g_save_printer_buffer_command)) {
         std::vector<uint8_t> data = m_beeb_thread->GetPrinterData();
 
-        SaveFileDialog fd(RECENT_PATHS_PRINTER);
+        // Store the data for the callback
+        m_pending_printer_data = data;
 
-        fd.AddFilter("Data", {".dat"});
+        // Pause the emulator while the dialog is open
+        this->PauseEmulatorForDialog();
 
-        std::string path;
-        if (fd.Open(&path)) {
-            SaveFile(data, path, &m_msg);
-        }
+        auto fd = CreateSaveFileDialog(RECENT_PATHS_PRINTER);
+        fd->AddFilter("Data", {".dat"});
+        fd->OpenWithCallback([this](const std::string& path) {
+            if (!path.empty()) {
+                SaveFile(m_pending_printer_data, path, &m_msg);
+            }
+            m_pending_printer_data.clear();
+            this->ResumeEmulatorAfterDialog();
+        });
     }
 
     DoCopyModeCommands(&m_settings.printer_copy_settings,
@@ -1588,16 +1634,21 @@ void BeebWindow::DoCommands(bool *close_window) {
     }
 
     if (m_cst.WasActioned(g_save_screenshot_command)) {
-        SaveFileDialog fd(RECENT_PATHS_SCREENSHOT);
+        // Create screenshot data first (before dialog)
+        SDLUniquePtr<SDL_Surface> screenshot = this->CreateScreenshot(SDL_PIXELFORMAT_RGB24);
+        if (!!screenshot) {
+            // Store screenshot data for callback
+            m_pending_screenshot = std::move(screenshot);
 
-        fd.AddFilter("PNG", {".png"});
-
-        std::string path;
-        if (fd.Open(&path)) {
-            SDLUniquePtr<SDL_Surface> screenshot = this->CreateScreenshot(SDL_PIXELFORMAT_RGB24);
-            if (!!screenshot) {
-                SaveSDLSurface(screenshot.get(), path, &m_msg);
-            }
+            // Use the new callback-based interface
+            auto fd = CreateSaveFileDialog(RECENT_PATHS_SCREENSHOT);
+            fd->AddFilter("PNG", {".png"});
+            fd->OpenWithCallback([this](const std::string& path) {
+                if (!path.empty() && m_pending_screenshot) {
+                    SaveSDLSurface(m_pending_screenshot.get(), path, &m_msg);
+                }
+                m_pending_screenshot.reset();
+            });
         }
     }
 
@@ -2122,20 +2173,28 @@ void BeebWindow::DoDiscDriveSubMenu(int drive,
         }
 
         if (ImGui::MenuItem("Save copy as...")) {
-            SaveFileDialog fd(RECENT_PATHS_DISC_IMAGE);
+            // Store the disc image for the callback
+            m_pending_disc_image = disc_image;
+
+            // Store the dialog as member variable to keep it alive for recent paths
+            m_pending_disc_dialog = CreateSaveFileDialog(RECENT_PATHS_DISC_IMAGE);
 
             std::vector<FileDialogFilter> filters = disc_image->GetFileDialogFilters();
             for (const FileDialogFilter &filter : filters) {
-                fd.AddFilter(filter.name, filter.extensions);
+                m_pending_disc_dialog->AddFilter(filter.name, filter.extensions);
             }
-            fd.AddAllFilesFilter();
+            m_pending_disc_dialog->AddAllFilesFilter();
 
-            std::string path;
-            if (fd.Open(&path)) {
-                if (disc_image->SaveToFile(path, &m_msg)) {
-                    fd.AddLastPathToRecentPaths();
+            m_pending_disc_dialog->OpenWithCallback([this](const std::string& path) {
+                if (!path.empty() && m_pending_disc_image) {
+                    if (m_pending_disc_image->SaveToFile(path, &m_msg)) {
+                        // Now we can call this because m_pending_disc_dialog is still alive
+                        m_pending_disc_dialog->AddLastPathToRecentPaths(path);
+                    }
                 }
-            }
+                m_pending_disc_image = nullptr;
+                m_pending_disc_dialog.reset(); // Clean up the dialog
+            });
         }
     }
 }
@@ -2152,10 +2211,12 @@ void BeebWindow::DoDiscImageSubMenu(int drive, bool boot) {
                              "New disc image",
                              "Disc image...",
                              "Recent disc image",
-                             &m_msg);
+                             &m_msg,
+                             this);
+    direct_item.CheckPendingResult(this); // Check for async results
     if (direct_item.load) {
         if (direct_item.new_disc_type) {
-            if (!SaveFile(direct_item.new_disc_data,
+            if (!SaveFile(*direct_item.new_disc_data,
                           direct_item.path,
                           &m_msg)) {
                 return;
@@ -2174,14 +2235,16 @@ void BeebWindow::DoDiscImageSubMenu(int drive, bool boot) {
                            "New in-memory disc image",
                            "In-memory disc image...",
                            "Recent in-memory disc image",
-                           &m_msg);
+                           &m_msg,
+                           this);
+    file_item.CheckPendingResult(this); // Check for async results
     if (file_item.load) {
         std::shared_ptr<MemoryDiscImage> new_disc_image;
         if (file_item.new_disc_type) {
             new_disc_image = MemoryDiscImage::LoadFromBuffer(file_item.path,
                                                              MemoryDiscImage::LOAD_METHOD_FILE,
-                                                             file_item.new_disc_data.data(),
-                                                             file_item.new_disc_data.size(),
+                                                             file_item.new_disc_data->data(),
+                                                             file_item.new_disc_data->size(),
                                                              *file_item.new_disc_type->geometry,
                                                              &m_msg);
         } else {
@@ -2522,10 +2585,14 @@ void BeebWindow::DoDebugMenu() {
             ImGui::EndMenu();
 
             if (load_symbols) {
-                OpenFileDialog fd(RECENT_PATHS_SYMBOLS);
+                // Store the selected parser for the callback
+                m_pending_symbol_parser = const_cast<SymbolTable::SymbolParser*>(selected_parser);
+
+                // Store the dialog as member variable to keep it alive for recent paths
+                m_pending_symbol_dialog = std::make_unique<OpenFileDialog>(RECENT_PATHS_SYMBOLS);
 
                 if (selected_parser) {
-                    fd.AddFilter(selected_parser->GetFormatName(), selected_parser->GetSuggestedFileExtensions());
+                    m_pending_symbol_dialog->AddFilter(selected_parser->GetFormatName(), selected_parser->GetSuggestedFileExtensions());
                 } else {
                     std::set<std::string> auto_detect_exts;
                     for (const std::unique_ptr<const SymbolTable::SymbolParser> &parser : parsers) {
@@ -2533,21 +2600,29 @@ void BeebWindow::DoDebugMenu() {
                         auto_detect_exts.insert(exts.begin(), exts.end());
                     }
 
-                    fd.AddFilter("Auto detect", std::vector<std::string>(auto_detect_exts.begin(), auto_detect_exts.end()));
+                    m_pending_symbol_dialog->AddFilter("Auto detect", std::vector<std::string>(auto_detect_exts.begin(), auto_detect_exts.end()));
                 }
 
-                fd.AddAllFilesFilter();
+                m_pending_symbol_dialog->AddAllFilesFilter();
 
-                std::string path;
-                if (fd.Open(&path)) {
-                    // The settings can be modified once the symbol file is loaded.
-                    bool success = m_symbol_table->LoadFromFile(path, selected_parser, &m_msg);
-                    if (success) {
-                        m_msg.i.f("Symbols loaded from file: %s\n", path.c_str());
-                    } else {
-                        m_msg.e.f("Failed to load symbols from: %s\n", path.c_str());
+                m_pending_symbol_dialog->OpenWithCallback([this](const std::string& path) {
+                    if (!path.empty()) {
+                        // The settings can be modified once the symbol file is loaded.
+                        const SymbolTable::SymbolParser* parser = static_cast<const SymbolTable::SymbolParser*>(m_pending_symbol_parser);
+                        bool success = m_symbol_table->LoadFromFile(path, parser, &m_msg);
+                        if (success) {
+                            m_msg.i.f("Symbols loaded from file: %s\n", path.c_str());
+                            // Update recent paths
+                            m_pending_symbol_dialog->AddLastPathToRecentPaths(path);
+                        } else {
+                            m_msg.e.f("Failed to load symbols from: %s\n", path.c_str());
+                        }
                     }
-                }
+
+                    // Clean up
+                    m_pending_symbol_parser = nullptr;
+                    m_pending_symbol_dialog.reset();
+                });
             }
         }
 
@@ -3978,6 +4053,25 @@ bool BeebWindow::DebugIsRunEnabled() const {
 BBCMicroHaltReason BeebWindow::DebugGetHaltReason() const {
     return m_beeb_thread->DebugGetHaltReason();
 }
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+void BeebWindow::PauseEmulatorForDialog() {
+    m_beeb_thread->Send(std::make_shared<BeebThread::CallbackMessage>([](BBCMicro *m) -> void {
+        m->DebugHalt(BBCMicroHaltReason_ManualHalt, nullptr, -1);
+    }));
+}
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+void BeebWindow::ResumeEmulatorAfterDialog() {
+    m_beeb_thread->Send(std::make_shared<BeebThread::CallbackMessage>([](BBCMicro *m) -> void {
+        m->DebugRun();
+    }));
+}
+
 #endif
 
 //////////////////////////////////////////////////////////////////////////

--- a/src/b2/BeebWindow.cpp
+++ b/src/b2/BeebWindow.cpp
@@ -1572,7 +1572,9 @@ void BeebWindow::DoCommands(bool *close_window) {
         m_pending_printer_data = data;
 
         // Pause the emulator while the dialog is open
+#if BBCMICRO_DEBUGGER
         this->PauseEmulatorForDialog();
+#endif
 
         auto fd = CreateSaveFileDialog(RECENT_PATHS_PRINTER);
         fd->AddFilter("Data", {".dat"});
@@ -1581,7 +1583,9 @@ void BeebWindow::DoCommands(bool *close_window) {
                 SaveFile(m_pending_printer_data, path, &m_msg);
             }
             m_pending_printer_data.clear();
+#if BBCMICRO_DEBUGGER
             this->ResumeEmulatorAfterDialog();
+#endif
         });
     }
 

--- a/src/b2/BeebWindow.h
+++ b/src/b2/BeebWindow.h
@@ -5,6 +5,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "conf.h"
+#include "discs.h"
 
 struct BeebWindowInitArguments;
 class VBlankMonitor;
@@ -342,6 +343,11 @@ class BeebWindow {
     BBCMicroHaltReason DebugGetHaltReason() const;
     void DebugStepOver(uint32_t dso);
     void DebugStepIn(uint32_t dso);
+
+    // Helper methods for pausing/resuming emulator during dialogs
+    void PauseEmulatorForDialog();
+    void ResumeEmulatorAfterDialog();
+
 #endif
 
     // Handle double click or drag'n'drop.
@@ -429,6 +435,32 @@ class BeebWindow {
     // Buffer for SDL keyboard events, so they can be handled as part of
     // the usual update.
     std::vector<SDL_KeyboardEvent> m_sdl_keyboard_events;
+
+    // For async dialog callbacks
+    std::vector<uint8_t> m_pending_printer_data;
+    SDLUniquePtr<SDL_Surface> m_pending_screenshot;
+    std::shared_ptr<const DiscImage> m_pending_disc_image;
+    std::unique_ptr<SaveFileDialog> m_pending_disc_dialog;
+
+    // For async symbol file open dialog
+    void* m_pending_symbol_parser = nullptr; // Will be cast to SymbolTable::SymbolParser*
+    std::unique_ptr<OpenFileDialog> m_pending_symbol_dialog;
+
+    // For async FileMenuItem operations - need to persist until callbacks complete
+    struct FileMenuItemState {
+        std::string path;
+        const Disc *new_disc_type = nullptr;
+        std::shared_ptr<std::vector<uint8_t>> new_disc_data;
+        SelectorDialog *used_dialog = nullptr;
+        bool load = false;
+        int drive = -1;
+        bool boot = false;
+    };
+    FileMenuItemState m_pending_file_menu_item;
+
+    // Friend class to allow FileMenuItem to access private members
+    friend class FileMenuItem;
+
 
     BeebWindowSettings m_settings;
 

--- a/src/b2/CMakeLists.txt
+++ b/src/b2/CMakeLists.txt
@@ -196,9 +196,9 @@ elseif(WIN32)
   target_sources(b2 PRIVATE
     native_ui_windows.cpp native_ui_windows.h)
 elseif(LINUX)
-  target_compile_definitions(b2 PRIVATE ${GTK2_DEFINITIONS})
-  target_include_directories(b2 PRIVATE ${GTK2_INCLUDE_DIRS})
-  target_link_libraries(b2 PRIVATE ${GTK2_LIBRARIES})
+  target_compile_definitions(b2 PRIVATE ${GTK4_DEFINITIONS})
+  target_include_directories(b2 PRIVATE ${GTK4_INCLUDE_DIRS})
+  target_link_libraries(b2 PRIVATE ${GTK4_LIBRARIES})
   target_sources(b2 PRIVATE native_ui_gtk.cpp native_ui_gtk.h)
 endif()
 

--- a/src/b2/ConfigsUI.cpp
+++ b/src/b2/ConfigsUI.cpp
@@ -57,6 +57,21 @@ class ConfigsUI : public SettingsUI {
     SaveFileDialog m_new_hard_disk_sfd;
     int m_config_index = -1;
 
+    // For async dialog callbacks
+    int m_pending_hard_disk_index = -1;
+    BeebConfig* m_pending_config = nullptr;
+    bool* m_pending_edited = nullptr;
+
+    // For new hard disk creation
+    const HardDisk* m_pending_new_disk = nullptr;
+    int m_pending_new_hard_disk_index = -1;
+    BeebConfig* m_pending_new_config = nullptr;
+    bool* m_pending_new_edited = nullptr;
+
+    // For ROM file loading
+    BeebConfig::ROM* m_pending_rom = nullptr;
+    bool* m_pending_rom_edited = nullptr;
+
     void DoROMInfoGui(const char *caption, const BeebConfig::ROM &rom, const bool *writeable);
 
     // rom_edit_flags is a combination of ROMEditFlag values
@@ -497,10 +512,25 @@ void ConfigsUI::DoEditConfigGui() {
 
                 if (ImGui::BeginPopup(SCSI_POPUP)) {
                     if (ImGui::MenuItem("File...")) {
-                        if (m_hard_disk_ofd.Open(&config->hard_disk_dat_paths[hard_disk_index])) {
-                            edited = true;
-                            m_hard_disk_ofd.AddLastPathToRecentPaths();
-                        }
+                        // Store the context for the callback
+                        m_pending_hard_disk_index = (int)hard_disk_index;
+                        m_pending_config = config;
+                        m_pending_edited = &edited;
+
+                        // Use the existing member dialog to preserve recent paths
+                        m_hard_disk_ofd.OpenWithCallback([this](const std::string& path) {
+                            if (!path.empty() && m_pending_config && m_pending_edited && m_pending_hard_disk_index >= 0) {
+                                m_pending_config->hard_disk_dat_paths[static_cast<size_t>(m_pending_hard_disk_index)] = path;
+                                *m_pending_edited = true;
+                                // Update recent paths
+                                m_hard_disk_ofd.AddLastPathToRecentPaths(path);
+                            }
+
+                            // Clean up
+                            m_pending_hard_disk_index = -1;
+                            m_pending_config = nullptr;
+                            m_pending_edited = nullptr;
+                        });
                     }
 
                     if (ImGuiRecentMenu(&config->hard_disk_dat_paths[hard_disk_index],
@@ -515,13 +545,29 @@ void ConfigsUI::DoEditConfigGui() {
                         for (size_t blank_hard_disk_index = 0; blank_hard_disk_index < NUM_BLANK_HARD_DISKS; ++blank_hard_disk_index) {
                             const HardDisk *disk = &BLANK_HARD_DISKS[blank_hard_disk_index];
                             if (ImGui::MenuItem(disk->name.c_str())) {
-                                std::string dat_path;
-                                if (m_new_hard_disk_sfd.Open(&dat_path)) {
-                                    if (this->CreateNewHardDiskImage(*disk, dat_path)) {
-                                        config->hard_disk_dat_paths[hard_disk_index] = dat_path;
-                                        edited = true;
+                                // Store the context for the callback
+                                m_pending_new_disk = disk;
+                                m_pending_new_hard_disk_index = (int)hard_disk_index;
+                                m_pending_new_config = config;
+                                m_pending_new_edited = &edited;
+
+                                // Use the existing member dialog to preserve recent paths
+                                m_new_hard_disk_sfd.OpenWithCallback([this](const std::string& path) {
+                                    if (!path.empty() && m_pending_new_disk && m_pending_new_config && m_pending_new_edited && m_pending_new_hard_disk_index >= 0) {
+                                        if (this->CreateNewHardDiskImage(*m_pending_new_disk, path)) {
+                                            m_pending_new_config->hard_disk_dat_paths[static_cast<size_t>(m_pending_new_hard_disk_index)] = path;
+                                            *m_pending_new_edited = true;
+                                            // Update recent paths
+                                            m_new_hard_disk_sfd.AddLastPathToRecentPaths(path);
+                                        }
                                     }
-                                }
+
+                                    // Clean up
+                                    m_pending_new_disk = nullptr;
+                                    m_pending_new_hard_disk_index = -1;
+                                    m_pending_new_config = nullptr;
+                                    m_pending_new_edited = nullptr;
+                                });
                             }
                         }
                         ImGui::EndMenu();
@@ -824,11 +870,24 @@ ROMEditAction ConfigsUI::DoROMEditGui(const char *caption,
 
     if (ImGui::BeginPopup(ROM_POPUP)) {
         if (ImGui::MenuItem("File...")) {
-            if (m_rom_ofd.Open(&rom->file_name)) {
-                rom->standard_rom = nullptr;
-                edited = true;
-                m_rom_ofd.AddLastPathToRecentPaths();
-            }
+            // Store the context for the callback
+            m_pending_rom = rom;
+            m_pending_rom_edited = &edited;
+
+            // Use the existing member dialog to preserve recent paths
+            m_rom_ofd.OpenWithCallback([this](const std::string& path) {
+                if (!path.empty() && m_pending_rom && m_pending_rom_edited) {
+                    m_pending_rom->file_name = path;
+                    m_pending_rom->standard_rom = nullptr;
+                    *m_pending_rom_edited = true;
+                    // Update recent paths
+                    m_rom_ofd.AddLastPathToRecentPaths(path);
+                }
+
+                // Clean up
+                m_pending_rom = nullptr;
+                m_pending_rom_edited = nullptr;
+            });
         }
 
         if (ImGuiRecentMenu(&rom->file_name, "Recent file", m_rom_ofd)) {

--- a/src/b2/TimelineUI.cpp
+++ b/src/b2/TimelineUI.cpp
@@ -229,24 +229,38 @@ class TimelineUI : public SettingsUI {
                             if (ImGui::Button(format->description.c_str())) {
                                 ImGui::CloseCurrentPopup();
 
-                                SaveFileDialog fd(RECENT_PATHS_VIDEO);
-                                fd.AddFilter(format->description, {format->extension});
+                                // Store the context for the callback
+                                m_pending_format_index = format_index;
+                                m_pending_state = state;
 
-                                std::string path;
-                                if (fd.Open(&path)) {
-                                    fd.AddLastPathToRecentPaths();
+                                // Create and configure the dialog
+                                m_pending_video_dialog = std::make_unique<SaveFileDialog>(RECENT_PATHS_VIDEO);
+                                m_pending_video_dialog->AddFilter(format->description, {format->extension});
 
-                                    if (PathGetExtension(path).empty()) {
-                                        path += format->extension;
+                                m_pending_video_dialog->OpenWithCallback([this](const std::string& path) {
+                                    if (!path.empty() && m_pending_video_dialog) {
+                                        std::string final_path = path;
+
+                                        // Add extension if not present
+                                        if (PathGetExtension(final_path).empty()) {
+                                            const VideoWriterFormat *format = GetVideoWriterFormatByIndex(m_pending_format_index);
+                                            final_path += format->extension;
+                                        }
+
+                                        std::unique_ptr<VideoWriter> video_writer = CreateVideoWriter(m_beeb_window->GetMessageList(),
+                                                                                                      std::move(final_path),
+                                                                                                      m_pending_format_index);
+                                        auto message = std::make_shared<BeebThread::CreateTimelineVideoMessage>(m_pending_state,
+                                                                                                                std::move(video_writer));
+                                        m_beeb_window->GetBeebThread()->Send(std::move(message));
+
+                                        // Update recent paths
+                                        m_pending_video_dialog->AddLastPathToRecentPaths(path);
                                     }
 
-                                    std::unique_ptr<VideoWriter> video_writer = CreateVideoWriter(m_beeb_window->GetMessageList(),
-                                                                                                  std::move(path),
-                                                                                                  format_index);
-                                    auto message = std::make_shared<BeebThread::CreateTimelineVideoMessage>(state,
-                                                                                                            std::move(video_writer));
-                                    m_beeb_window->GetBeebThread()->Send(std::move(message));
-                                }
+                                    // Clean up
+                                    m_pending_video_dialog.reset();
+                                });
                             }
                         }
 
@@ -283,6 +297,11 @@ class TimelineUI : public SettingsUI {
     ThumbnailsUI m_thumbnails;
     bool m_follow = true;
     size_t m_old_num_beeb_state_events = 0;
+
+    // For async video export dialog
+    size_t m_pending_format_index = 0;
+    std::shared_ptr<const BeebState> m_pending_state;
+    std::unique_ptr<SaveFileDialog> m_pending_video_dialog;
 };
 
 ////////////////////////////////////////////////////////////////////////////

--- a/src/b2/TraceUI.cpp
+++ b/src/b2/TraceUI.cpp
@@ -498,7 +498,9 @@ void TraceUI::DoImGui() {
                 m_pending_save_trace = last_trace;
 
                 // Pause the emulator while the dialog is open (TraceUI's choice)
+#if BBCMICRO_DEBUGGER
                 m_beeb_window->PauseEmulatorForDialog();
+#endif
 
                 // Use the new async interface (works on all platforms)
                 auto fd = CreateSaveFileDialog(RECENT_PATHS_TRACES);
@@ -513,7 +515,9 @@ void TraceUI::DoImGui() {
                     }
 
                     // Resume the emulator regardless of whether the user saved or cancelled
+#if BBCMICRO_DEBUGGER
                     m_beeb_window->ResumeEmulatorAfterDialog();
+#endif
                 });
             }
 

--- a/src/b2/TraceUI.cpp
+++ b/src/b2/TraceUI.cpp
@@ -70,6 +70,14 @@ class TraceUI : public SettingsUI {
     std::shared_ptr<SaveTraceJob> m_save_trace_job;
     std::vector<uint8_t> m_keys;
 
+    // For async save callback
+    std::shared_ptr<Trace> m_pending_save_trace;
+
+    // For async auto-save path dialog
+    std::unique_ptr<SaveFileDialog> m_pending_auto_save_dialog;
+
+
+
     char m_stop_num_cycles_str[100] = {};
     char m_start_instruction_address_str[100] = {};
     char m_start_write_address_str[100] = {};
@@ -422,11 +430,23 @@ void TraceUI::DoImGui() {
         ImGui::Checkbox("Auto-save on stop", &g_default_settings.auto_save);
         if (g_default_settings.auto_save) {
             if (ImGui::Button("...")) {
-                SaveFileDialog fd(RECENT_PATHS_TRACES);
+                // Create and configure the dialog
+                m_pending_auto_save_dialog = std::make_unique<SaveFileDialog>(RECENT_PATHS_TRACES);
+                m_pending_auto_save_dialog->AddFilter("Text files", {".txt"});
+                m_pending_auto_save_dialog->AddAllFilesFilter();
 
-                fd.AddFilter("Text files", {".txt"});
-                fd.AddAllFilesFilter();
-                fd.Open(&g_default_settings.auto_save_path);
+                m_pending_auto_save_dialog->OpenWithCallback([this](const std::string& path) {
+                    if (!path.empty() && m_pending_auto_save_dialog) {
+                        // Update the global auto-save path
+                        g_default_settings.auto_save_path = path;
+
+                        // Update recent paths
+                        m_pending_auto_save_dialog->AddLastPathToRecentPaths(path);
+                    }
+
+                    // Clean up
+                    m_pending_auto_save_dialog.reset();
+                });
             }
             ImGui::SameLine();
             ImGuiInputText(&g_default_settings.auto_save_path, "Path", g_default_settings.auto_save_path);
@@ -474,16 +494,27 @@ void TraceUI::DoImGui() {
             DoTraceStatsImGui(&stats);
 
             if (ImGui::Button("Save...")) {
-                SaveFileDialog fd(RECENT_PATHS_TRACES);
+                // Store the trace for the callback
+                m_pending_save_trace = last_trace;
 
-                fd.AddFilter("Text files", {".txt"});
-                fd.AddAllFilesFilter();
+                // Pause the emulator while the dialog is open (TraceUI's choice)
+                m_beeb_window->PauseEmulatorForDialog();
 
-                std::string path;
-                if (fd.Open(&path)) {
-                    fd.AddLastPathToRecentPaths();
-                    this->StartSaveTraceJob(last_trace, std::move(path));
-                }
+                // Use the new async interface (works on all platforms)
+                auto fd = CreateSaveFileDialog(RECENT_PATHS_TRACES);
+                fd->AddFilter("Text files", {".txt"});
+                fd->AddAllFilesFilter();
+                fd->OpenWithCallback([this](const std::string& path) {
+                    if (!path.empty()) {
+                        if (m_pending_save_trace) {
+                            StartSaveTraceJob(m_pending_save_trace, path);
+                            m_pending_save_trace.reset();
+                        }
+                    }
+
+                    // Resume the emulator regardless of whether the user saved or cancelled
+                    m_beeb_window->ResumeEmulatorAfterDialog();
+                });
             }
 
             ImGui::SameLine();

--- a/src/b2/VideoWriterFFmpeg.cpp
+++ b/src/b2/VideoWriterFFmpeg.cpp
@@ -633,7 +633,7 @@ static bool IsChannelLayoutSupported(const AVCodec *codec,
     }
 
     for (const uint64_t *codec_layout = codec->channel_layouts; *codec_layout != 0; ++codec_layout) {
-        if (codec_layout == requested_layout) {
+        if (*codec_layout == requested_layout) {
             return true;
         }
     }

--- a/src/b2/b2.cpp
+++ b/src/b2/b2.cpp
@@ -47,6 +47,7 @@
 G_GNUC_BEGIN_IGNORE_DEPRECATIONS
 #include <gtk/gtk.h>
 G_GNUC_END_IGNORE_DEPRECATIONS
+#include "native_ui_gtk.h"
 #endif
 #include "BeebLinkHTTPHandler.h"
 #include "joysticks.h"
@@ -1412,7 +1413,7 @@ static bool main2(int argc, char *argv[], const std::shared_ptr<MessageList> &in
 #if SYSTEM_LINUX
     // Need to do this after SDL_Init. See, e.g.,
     // https://discourse.libsdl.org/t/gtk2-sdl2-partial-fail/19274
-    gtk_init(&argc, &argv);
+    gtk_init();
 #endif
 
 #if SYSTEM_WINDOWS
@@ -1561,6 +1562,9 @@ static bool main2(int argc, char *argv[], const std::shared_ptr<MessageList> &in
                     goto done;
                 }
             }
+
+            // Process GTK events to handle async operations
+            ProcessGTKEvents();
 
             if (event.type == SDL_QUIT) {
 #if SYSTEM_OSX

--- a/src/b2/b2.cpp
+++ b/src/b2/b2.cpp
@@ -1563,8 +1563,10 @@ static bool main2(int argc, char *argv[], const std::shared_ptr<MessageList> &in
                 }
             }
 
-            // Process GTK events to handle async operations
+            // Process GTK events to handle async operations (Linux only)
+#if SYSTEM_LINUX
             ProcessGTKEvents();
+#endif
 
             if (event.type == SDL_QUIT) {
 #if SYSTEM_OSX

--- a/src/b2/debugger.cpp
+++ b/src/b2/debugger.cpp
@@ -1443,34 +1443,46 @@ class MemoryDebugWindow : public DebugUIWithPersistentData<MemoryDebugWindowPers
                 ImGuiStyleColourPusher pusher;
                 pusher.PushDisabledButtonColours(!save_enabled);
                 if (ImGui::Button("Save memory...") && save_enabled) {
-                    SaveFileDialog fd("save_memory");
+                    // Store the save parameters for the callback
+                    m_window->m_pending_save_begin = begin;
+                    m_window->m_pending_save_end_or_size = end_or_size;
+                    m_window->m_pending_save_mos = this->mos;
 
-                    fd.AddAllFilesFilter();
+                    // Store the dialog as member variable to keep it alive for recent paths
+                    m_window->m_pending_memory_dialog = CreateSaveFileDialog("save_memory");
+                    m_window->m_pending_memory_dialog->AddAllFilesFilter();
 
-                    std::string path;
-                    if (fd.Open(&path)) {
-                        uint32_t end;
-                        if (m_window->m_persistent.specify_end) {
-                            end = end_or_size;
-                        } else {
-                            end = begin + end_or_size;
+                    m_window->m_pending_memory_dialog->OpenWithCallback([this](const std::string& path) {
+                        if (!path.empty()) {
+                            uint32_t end;
+                            if (m_window->m_persistent.specify_end) {
+                                end = m_window->m_pending_save_end_or_size;
+                            } else {
+                                end = m_window->m_pending_save_begin + m_window->m_pending_save_end_or_size;
+                            }
+
+                            // (this clamp means that addr has to be the full 32
+                            // bits. But this value is the terminating value, so the
+                            // cast to uint16_t inside the loop is quite safe.)
+                            end = std::min(end, 0x10000u);
+
+                            std::vector<uint8_t> buffer;
+                            for (uint32_t addr = m_window->m_pending_save_begin; addr != end; ++addr) {
+                                uint8_t value;
+                                m_window->ReadByte(&value, nullptr, nullptr, (uint16_t)addr, m_window->m_pending_save_mos);
+                                buffer.push_back(value);
+                            }
+
+                            Messages msgs(m_window->m_beeb_window->GetMessageList());
+                            SaveFile(buffer, path, &msgs);
+
+                            // Update recent paths
+                            m_window->m_pending_memory_dialog->AddLastPathToRecentPaths(path);
                         }
 
-                        // (this clamp means that addr has to be the full 32
-                        // bits. But this value is the terminating value, so the
-                        // cast to uint16_t inside the loop is quite safe.)
-                        end = std::min(end, 0x10000u);
-
-                        std::vector<uint8_t> buffer;
-                        for (uint32_t addr = begin; addr != end; ++addr) {
-                            uint8_t value;
-                            m_window->ReadByte(&value, nullptr, nullptr, (uint16_t)addr, this->mos);
-                            buffer.push_back(value);
-                        }
-
-                        Messages msgs(m_window->m_beeb_window->GetMessageList());
-                        SaveFile(buffer, path, &msgs);
-                    }
+                        // Clean up
+                        m_window->m_pending_memory_dialog.reset();
+                    });
                 }
             }
         }
@@ -1550,6 +1562,12 @@ class MemoryDebugWindow : public DebugUIWithPersistentData<MemoryDebugWindowPers
     bool m_show_mos_toggle = false;
     Handler m_handler;
     HexEditor m_hex_editor;
+
+    // For async memory save dialog
+    uint16_t m_pending_save_begin = 0;
+    uint32_t m_pending_save_end_or_size = 0;
+    bool m_pending_save_mos = false;
+    std::unique_ptr<SaveFileDialog> m_pending_memory_dialog;
 };
 
 std::unique_ptr<SettingsUI> CreateHostMemoryDebugWindow(BeebWindow *beeb_window) {

--- a/src/b2/native_ui.cpp
+++ b/src/b2/native_ui.cpp
@@ -194,10 +194,16 @@ void SelectorDialog::AddLastPathToRecentPaths() {
     }
 }
 
+void SelectorDialog::AddLastPathToRecentPaths(const std::string& path) {
+    m_last_path = path;
+    AddLastPathToRecentPaths();
+}
+
 //////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////
 
-bool SelectorDialog::Open(std::string *path) {
+void SelectorDialog::OpenWithCallback(std::function<void(const std::string&)> callback) {
+    // Set up last path if needed
     if (m_last_path.empty()) {
         if (RecentPaths *recent = GetRecentPathsByTag(m_recent_paths_tag)) {
             if (recent->GetNumPaths() > 0) {
@@ -206,15 +212,24 @@ bool SelectorDialog::Open(std::string *path) {
         }
     }
 
+    // Call the platform-specific callback implementation with a wrapper that handles m_last_path
+    this->HandleOpenWithCallback([this, callback](const std::string& result) {
+        // Update m_last_path based on result (same logic as synchronous Open method)
+        if (result.empty()) {
+            m_last_path.clear();        // Clear if cancelled/empty
+        } else {
+            m_last_path = result;       // Update with successful result
+        }
+
+        // Call the original callback
+        callback(result);
+    });
+}
+
+void SelectorDialog::HandleOpenWithCallback(std::function<void(const std::string&)> callback) {
+    // Default implementation: fall back to synchronous
     std::string result = this->HandleOpen();
-    if (result.empty()) {
-        m_last_path.clear();
-        return false;
-    } else {
-        m_last_path = result;
-        *path = m_last_path;
-        return true;
-    }
+    callback(result);
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -276,8 +291,22 @@ std::string OpenFileDialog::HandleOpen() {
 
 #else
 
-    return OpenFileDialogGTK(m_filters, m_last_path);
+    // Linux uses async dialogs, so this synchronous method should never be called
+    // Return empty string as fallback
+    return "";
 
+#endif
+}
+
+void OpenFileDialog::HandleOpenWithCallback(std::function<void(const std::string&)> callback) {
+#if SYSTEM_LINUX
+    // Use callback-based GTK4 implementation on Linux
+    OpenFileDialogGTKAsync(m_filters, m_last_path, [callback](const std::string& path) {
+        callback(path);
+    });
+#else
+    // Use synchronous fallback on other platforms
+    SelectorDialog::HandleOpenWithCallback(callback);
 #endif
 }
 
@@ -286,6 +315,11 @@ std::string OpenFileDialog::HandleOpen() {
 
 SaveFileDialog::SaveFileDialog(std::string tag)
     : FileDialog(std::move(tag)) {
+}
+
+// Factory function to create platform-specific SaveFileDialog
+std::unique_ptr<SaveFileDialog> CreateSaveFileDialog(std::string tag) {
+    return std::make_unique<SaveFileDialog>(std::move(tag));
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -303,8 +337,20 @@ std::string SaveFileDialog::HandleOpen() {
 
 #else
 
-    return SaveFileDialogGTK(m_filters, m_last_path);
+    // Linux uses async dialogs, so this synchronous method should never be called
+    // Return empty string as fallback
+    return "";
 
+#endif
+}
+
+void SaveFileDialog::HandleOpenWithCallback(std::function<void(const std::string&)> callback) {
+#if SYSTEM_LINUX
+    // Use callback-based GTK4 implementation on Linux
+    SaveFileDialogGTKAsync(m_filters, m_last_path, callback);
+#else
+    // Use synchronous fallback on other platforms
+    SelectorDialog::HandleOpenWithCallback(callback);
 #endif
 }
 
@@ -332,8 +378,9 @@ std::string FolderDialog::HandleOpen() {
 
 #else
 
-    std::string r = SelectFolderDialogGTK(m_last_path);
-    return r;
+    // Linux uses async dialogs, so this synchronous method should never be called
+    // Return empty string as fallback
+    return "";
 
 #endif
 }

--- a/src/b2/native_ui.h
+++ b/src/b2/native_ui.h
@@ -80,11 +80,18 @@ class SelectorDialog {
     RecentPaths *GetRecentPaths() const;
     //void SetRecentPathsTag(std::string tag);
     void AddLastPathToRecentPaths();
+    void AddLastPathToRecentPaths(const std::string& path);
 
     bool Open(std::string *path);
 
+    // New callback-based interface
+    void OpenWithCallback(std::function<void(const std::string&)> callback);
+
   protected:
     virtual std::string HandleOpen() = 0;
+
+    // New callback-based implementation (optional override)
+    virtual void HandleOpenWithCallback(std::function<void(const std::string&)> callback);
 
     std::string m_last_path;
 
@@ -127,6 +134,7 @@ class OpenFileDialog : public FileDialog {
 
   protected:
     std::string HandleOpen() override;
+    void HandleOpenWithCallback(std::function<void(const std::string&)> callback) override;
 
   private:
 };
@@ -140,9 +148,13 @@ class SaveFileDialog : public FileDialog {
 
   protected:
     std::string HandleOpen() override;
+    void HandleOpenWithCallback(std::function<void(const std::string&)> callback) override;
 
   private:
 };
+
+// Factory function to create platform-specific SaveFileDialog
+std::unique_ptr<SaveFileDialog> CreateSaveFileDialog(std::string tag);
 
 //////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////

--- a/src/b2/native_ui_gtk.cpp
+++ b/src/b2/native_ui_gtk.cpp
@@ -83,74 +83,69 @@ void SetClipboardImage(SDL_Surface *surface, Messages *messages) {
 //////////////////////////////////////////////////////////////////////////
 
 void MessageBox(const std::string &title, const std::string &text) {
-    GtkWidget *dialog = gtk_message_dialog_new(nullptr,
-                                               GTK_DIALOG_MODAL,
-                                               GTK_MESSAGE_ERROR,
-                                               GTK_BUTTONS_OK,
-                                               "%s",
-                                               title.c_str());
-    gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog),
-                                             "%s",
-                                             text.c_str());
-    gtk_dialog_run(GTK_DIALOG(dialog));
-    gtk_widget_destroy(dialog);
-}
-
-//////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////
-
-static GtkWidget *CreateFileDialog(const char *title,
-                                   GtkFileChooserAction action) {
-    GtkWidget *gdialog = gtk_file_chooser_dialog_new(title,
-                                                     nullptr,
-                                                     action,
-                                                     "_Cancel", GTK_RESPONSE_CANCEL,
-                                                     "_Open", GTK_RESPONSE_ACCEPT,
-                                                     nullptr);
-    return gdialog;
-}
-
-//////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////
-
-static std::string RunFileDialog(GtkWidget *gdialog) {
-    gint gresult = gtk_dialog_run(GTK_DIALOG(gdialog));
-
-    std::string result;
-    if (gresult == GTK_RESPONSE_ACCEPT) {
-        if (const char *name = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(gdialog))) {
-            result.assign(name);
+    // Get the main application window as parent
+    GtkWindow *parent = nullptr;
+    GList *toplevels = gtk_window_list_toplevels();
+    if (toplevels) {
+        for (GList *iter = toplevels; iter; iter = iter->next) {
+            GtkWidget *window = GTK_WIDGET(iter->data);
+            if (gtk_widget_get_visible(window) && GTK_IS_WINDOW(window)) {
+                parent = GTK_WINDOW(window);
+                break;
+            }
         }
+        g_list_free(toplevels);
     }
 
-    gtk_widget_destroy(gdialog);
-    gdialog = nullptr;
+    GtkAlertDialog *alert = gtk_alert_dialog_new(title.c_str());
+    gtk_alert_dialog_set_detail(alert, text.c_str());
+    gtk_alert_dialog_set_modal(alert, TRUE);
 
-    while (gtk_events_pending()) {
-        gtk_main_iteration();
-    }
+    // Show the alert dialog
+    gtk_alert_dialog_show(alert, parent);
 
-    return result;
+    // Clean up
+    g_object_unref(alert);
 }
 
+
 //////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////
 
-static void SetDefaultPath(GtkWidget *gdialog,
-                           const std::string &default_path) {
-    if (!default_path.empty()) {
-        gtk_file_chooser_set_filename(GTK_FILE_CHOOSER(gdialog), default_path.c_str());
+static void (*g_trace_save_callback)(const std::string& path) = nullptr;
+
+// For std::function callbacks
+static std::function<void(const std::string&)> g_std_function_callback;
+
+// Dialog operation types
+enum class DialogOperation {
+    Save,
+    Open,
+    SelectFolder
+};
+
+static DialogOperation g_current_dialog_operation = DialogOperation::Save;
+
+// Function to process GTK events (to be called from main SDL loop)
+void ProcessGTKEvents() {
+    // Process any pending GTK events without blocking
+    while (g_main_context_pending(g_main_context_default())) {
+        g_main_context_iteration(g_main_context_default(), FALSE);
     }
 }
 
-//////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////
+// Helper function to create GTK4 file filters from our filter format
+static GListModel* CreateGTK4Filters(const std::vector<OpenFileDialog::Filter> &filters) {
+    if (filters.empty()) {
+        return nullptr;
+    }
 
-static void AddFilters(GtkWidget *gdialog,
-                       const std::vector<OpenFileDialog::Filter> &filters) {
+    GListStore *store = g_list_store_new(GTK_TYPE_FILE_FILTER);
+
     for (const OpenFileDialog::Filter &filter : filters) {
         GtkFileFilter *gfilter = gtk_file_filter_new();
 
+        // Set the filter name
         std::string name = filter.title + " (";
         for (size_t i = 0; i < filter.extensions.size(); ++i) {
             if (i > 0) {
@@ -159,57 +154,248 @@ static void AddFilters(GtkWidget *gdialog,
             name += "*" + filter.extensions[i];
         }
         name += ")";
-
         gtk_file_filter_set_name(gfilter, name.c_str());
 
+        // Add patterns for each extension
         for (const std::string &extension : filter.extensions) {
-            gtk_file_filter_add_pattern(gfilter, ("*" + extension).c_str());
+            if (extension == ".*") {
+                // Special case for "all files" filter
+                gtk_file_filter_add_pattern(gfilter, "*");
+            } else {
+                gtk_file_filter_add_pattern(gfilter, ("*" + extension).c_str());
+            }
         }
 
-        gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(gdialog), gfilter);
+        g_list_store_append(store, gfilter);
+        g_object_unref(gfilter); // The store takes ownership
     }
+
+    return G_LIST_MODEL(store);
 }
 
-//////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////
 
-std::string OpenFileDialogGTK(const std::vector<OpenFileDialog::Filter> &filters,
-                              const std::string &default_path) {
-    GtkWidget *gdialog = CreateFileDialog("Open File",
-                                          GTK_FILE_CHOOSER_ACTION_OPEN);
+// Callback for GTK4 async file dialog
+static void async_file_dialog_response_callback(GObject *source_object, GAsyncResult *res, gpointer user_data) {
+    (void)user_data; // Suppress unused parameter warning
+    GtkFileDialog *dialog = GTK_FILE_DIALOG(source_object);
+    GError *error = nullptr;
 
-    AddFilters(gdialog, filters);
-    SetDefaultPath(gdialog, default_path);
+    // Use the correct finish function based on the operation type
+    GFile *file = nullptr;
+    switch (g_current_dialog_operation) {
+        case DialogOperation::Save:
+            file = gtk_file_dialog_save_finish(dialog, res, &error);
+            break;
+        case DialogOperation::Open:
+            file = gtk_file_dialog_open_finish(dialog, res, &error);
+            break;
+        case DialogOperation::SelectFolder:
+            file = gtk_file_dialog_select_folder_finish(dialog, res, &error);
+            break;
+    }
 
-    return RunFileDialog(gdialog);
+    if (error) {
+        g_error_free(error);
+        if (g_trace_save_callback) {
+            g_trace_save_callback(""); // Empty path indicates error/cancellation
+        }
+        if (g_std_function_callback) {
+            g_std_function_callback(""); // Empty path indicates error/cancellation
+        }
+    } else if (file) {
+        char *path = g_file_get_path(file);
+        if (path) {
+            if (g_trace_save_callback) {
+                g_trace_save_callback(std::string(path));
+            }
+            if (g_std_function_callback) {
+                g_std_function_callback(std::string(path));
+            }
+            g_free(path);
+        }
+        g_object_unref(file);
+    } else {
+        if (g_trace_save_callback) {
+            g_trace_save_callback(""); // Empty path indicates cancellation
+        }
+        if (g_std_function_callback) {
+            g_std_function_callback(""); // Empty path indicates cancellation
+        }
+    }
+
+    // Clean up the dialog now that the async operation is complete
+    g_object_unref(dialog);
 }
 
-//////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////
 
-std::string SaveFileDialogGTK(const std::vector<OpenFileDialog::Filter> &filters,
-                              const std::string &default_path) {
-    GtkWidget *gdialog = CreateFileDialog("Save File",
-                                          GTK_FILE_CHOOSER_ACTION_SAVE);
+// Async function for Open File Dialog
+void OpenFileDialogGTKAsync(const std::vector<OpenFileDialog::Filter> &filters,
+                           const std::string &default_path,
+                           std::function<void(const std::string&)> callback) {
 
-    AddFilters(gdialog, filters);
-    SetDefaultPath(gdialog, default_path);
-    gtk_file_chooser_set_do_overwrite_confirmation(GTK_FILE_CHOOSER(gdialog), TRUE);
+    // Get the main application window as parent
+    GtkWindow *parent = nullptr;
+    GList *toplevels = gtk_window_list_toplevels();
+    if (toplevels) {
+        for (GList *iter = toplevels; iter; iter = iter->next) {
+            GtkWidget *window = GTK_WIDGET(iter->data);
+            if (gtk_widget_get_visible(window) && GTK_IS_WINDOW(window)) {
+                parent = GTK_WINDOW(window);
+                break;
+            }
+        }
+        g_list_free(toplevels);
+    }
 
-    return RunFileDialog(gdialog);
+    // Create GTK4 native file dialog
+    GtkFileDialog *file_dialog = gtk_file_dialog_new();
+
+    // Set dialog properties
+    gtk_file_dialog_set_title(file_dialog, "Open File");
+
+    // Apply file filters if provided
+    GListModel *gtk_filters = CreateGTK4Filters(filters);
+    if (gtk_filters) {
+        gtk_file_dialog_set_filters(file_dialog, gtk_filters);
+        g_object_unref(gtk_filters); // Clean up the list model
+    }
+
+    // Set initial folder if provided (extract directory from file path)
+    if (!default_path.empty()) {
+        std::string initial_folder_path = default_path;
+        size_t last_slash = default_path.find_last_of('/');
+        if (last_slash != std::string::npos && last_slash > 0) {
+            initial_folder_path = default_path.substr(0, last_slash);
+        }
+
+        GFile *initial_folder = g_file_new_for_path(initial_folder_path.c_str());
+        gtk_file_dialog_set_initial_folder(file_dialog, initial_folder);
+        g_object_unref(initial_folder);
+    }
+
+    // Store the callback for this operation
+    g_std_function_callback = callback;
+    g_current_dialog_operation = DialogOperation::Open;
+
+    // Start the async file dialog (non-blocking)
+    gtk_file_dialog_open(file_dialog, parent, nullptr, async_file_dialog_response_callback, nullptr);
+
+    // Don't unref the dialog - it needs to stay alive for the async operation
+    // The dialog will be cleaned up in the callback
 }
 
-//////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////
+// Async function for Select Folder Dialog
+void SelectFolderDialogGTKAsync(const std::string &default_path,
+                               void (*callback)(const std::string& path)) {
 
-std::string SelectFolderDialogGTK(const std::string &default_path) {
-    GtkWidget *gdialog = CreateFileDialog("Select Folder",
-                                          GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER);
+    // Get the main application window as parent
+    GtkWindow *parent = nullptr;
+    GList *toplevels = gtk_window_list_toplevels();
+    if (toplevels) {
+        for (GList *iter = toplevels; iter; iter = iter->next) {
+            GtkWidget *window = GTK_WIDGET(iter->data);
+            if (gtk_widget_get_visible(window) && GTK_IS_WINDOW(window)) {
+                parent = GTK_WINDOW(window);
+                break;
+            }
+        }
+        g_list_free(toplevels);
+    }
 
-    SetDefaultPath(gdialog, default_path);
+    // Create GTK4 native file dialog
+    GtkFileDialog *file_dialog = gtk_file_dialog_new();
 
-    return RunFileDialog(gdialog);
+    // Set dialog properties
+    gtk_file_dialog_set_title(file_dialog, "Select Folder");
+
+    // Set initial folder if provided
+    if (!default_path.empty()) {
+        GFile *initial_folder = g_file_new_for_path(default_path.c_str());
+        gtk_file_dialog_set_initial_folder(file_dialog, initial_folder);
+        g_object_unref(initial_folder);
+    }
+
+    // Set the callback and operation type for this operation
+    g_trace_save_callback = callback;
+    g_current_dialog_operation = DialogOperation::SelectFolder;
+
+    // Start the async folder selection dialog (non-blocking)
+    gtk_file_dialog_select_folder(file_dialog, parent, nullptr, async_file_dialog_response_callback, nullptr);
+
+    // Don't unref the dialog - it needs to stay alive for the async operation
+    // The dialog will be cleaned up in the callback
 }
+
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+// GTK-specific async implementation for SaveFileDialog
+void SaveFileDialogGTKAsync(const std::vector<OpenFileDialog::Filter> &filters,
+                           const std::string &default_path,
+                           std::function<void(const std::string&)> callback) {
+
+    // Get the main application window as parent
+    GtkWindow *parent = nullptr;
+    GList *toplevels = gtk_window_list_toplevels();
+    if (toplevels) {
+        for (GList *iter = toplevels; iter; iter = iter->next) {
+            GtkWidget *window = GTK_WIDGET(iter->data);
+            if (gtk_widget_get_visible(window) && GTK_IS_WINDOW(window)) {
+                parent = GTK_WINDOW(window);
+                break;
+            }
+        }
+        g_list_free(toplevels);
+    }
+
+    // Create GTK4 native file dialog
+    GtkFileDialog *file_dialog = gtk_file_dialog_new();
+
+    // Set dialog properties
+    gtk_file_dialog_set_title(file_dialog, "Save File");
+
+    // Apply file filters if provided
+    GListModel *gtk_filters = CreateGTK4Filters(filters);
+    if (gtk_filters) {
+        gtk_file_dialog_set_filters(file_dialog, gtk_filters);
+        g_object_unref(gtk_filters); // Clean up the list model
+    }
+
+    // Set initial folder if provided (extract directory from file path)
+    if (!default_path.empty()) {
+        std::string initial_folder_path = default_path;
+        size_t last_slash = default_path.find_last_of('/');
+        if (last_slash != std::string::npos && last_slash > 0) {
+            initial_folder_path = default_path.substr(0, last_slash);
+        }
+
+        GFile *initial_folder = g_file_new_for_path(initial_folder_path.c_str());
+        gtk_file_dialog_set_initial_folder(file_dialog, initial_folder);
+        g_object_unref(initial_folder);
+    }
+
+    // Store the callback for this operation
+    g_std_function_callback = callback;
+    g_current_dialog_operation = DialogOperation::Save;
+
+    // Start the async file dialog (non-blocking)
+    gtk_file_dialog_save(file_dialog, parent, nullptr, async_file_dialog_response_callback, nullptr);
+
+}
+
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
 
 //////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////

--- a/src/b2/native_ui_gtk.h
+++ b/src/b2/native_ui_gtk.h
@@ -6,6 +6,11 @@
 
 #include <vector>
 #include <string>
+#include <functional>
+
+// Forward declarations
+class OpenFileDialog;
+class SaveFileDialog;
 
 //////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////
@@ -15,13 +20,23 @@ void MessageBox(const std::string &title, const std::string &text);
 //////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////
 
-std::string OpenFileDialogGTK(const std::vector<OpenFileDialog::Filter> &filters,
-                              const std::string &default_path);
 
-std::string SaveFileDialogGTK(const std::vector<OpenFileDialog::Filter> &filters,
-                              const std::string &default_path);
+// std::function version for the interface
+void SaveFileDialogGTKAsync(const std::vector<OpenFileDialog::Filter> &filters,
+                           const std::string &default_path,
+                           std::function<void(const std::string&)> callback);
 
-std::string SelectFolderDialogGTK(const std::string &default_path);
+
+void OpenFileDialogGTKAsync(const std::vector<OpenFileDialog::Filter> &filters,
+                           const std::string &default_path,
+                           std::function<void(const std::string&)> callback);
+
+void SelectFolderDialogGTKAsync(const std::string &default_path,
+                               void (*callback)(const std::string& path));
+
+// Function to process GTK events (to be called from main SDL loop)
+void ProcessGTKEvents();
+
 
 //////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This is to fix #272 by implementing the GTK interface with async dialogs.

Summary: Migrate from GTK2 to GTK4 with Async Dialogs
Problem: GTK2 file dialogs caused "Application Not Responding" (ANR) warnings due to blocking gtk_dialog_run() calls.

Solution: Migrated to GTK4's native async GtkFileDialog API with callback-based interface. All file dialogs now use OpenWithCallback() pattern that:

- Linux: Uses GTK4 async dialogs (eliminates ANR issues)
- Windows/Mac: Falls back to existing synchronous implementations via SelectorDialog::HandleOpenWithCallback()
- Cross-platform: Maintains same interface while providing platform-appropriate behavior

Key Changes:
Replaced deprecated gtk_dialog_run() with gtk_file_dialog_save/open() + callbacks, removed ~100 lines of dead GTK2 code, and added proper m_last_path management in async callbacks.

Result: 
No more ANR warnings, modern GTK4 dialogs.
