### PR TITLE
Fix Tube register side effects during page-cross fix-up reads - allowing Chuckie Egg 2023 to run

### DIFF
--- a/src/6502/6502_gen.cpp
+++ b/src/6502/6502_gen.cpp
@@ -1004,7 +1004,7 @@ class InstrGen {
 
         case Cycle::Type::ReadDataNoCarry:
             P("assert(s->acarry==0||s->acarry==1);\n");
-            P("s->read=M6502ReadType_Data+s->acarry;\n");
+            P("s->read=s->acarry?M6502ReadType_Uninteresting:M6502ReadType_Data;\n");
             break;
 
         case Cycle::Type::ReadInstruction:

--- a/src/beeb/include/beeb/BBCMicro.h
+++ b/src/beeb/include/beeb/BBCMicro.h
@@ -592,6 +592,7 @@ class BBCMicro : private WD1770Handler {
 
     uint8_t *m_parasite_ram = nullptr;
     ReadMMIOFn m_parasite_read_mmio_fns[8] = {};
+    ReadMMIOFn m_parasite_peek_mmio_fns[8] = {};
     WriteMMIOFn m_parasite_write_mmio_fns[8] = {};
 
     const std::vector<float> *m_disc_drive_sounds[DiscDriveSound_EndValue];

--- a/src/beeb/include/beeb/tube.h
+++ b/src/beeb/include/beeb/tube.h
@@ -198,6 +198,18 @@ uint8_t ReadParasiteTube4(void *tube, M6502Word a);
 uint8_t ReadParasiteTube5(void *tube, M6502Word a);
 uint8_t ReadParasiteTube6(void *tube, M6502Word a);
 uint8_t ReadParasiteTube7(void *tube, M6502Word a);
+
+// Side-effect-free reads for page-cross fixup cycles.
+// Return the register value without consuming latch data or updating
+// interrupt flags.
+uint8_t PeekParasiteTube0(void *tube, M6502Word a);
+uint8_t PeekParasiteTube1(void *tube, M6502Word a);
+uint8_t PeekParasiteTube2(void *tube, M6502Word a);
+uint8_t PeekParasiteTube3(void *tube, M6502Word a);
+uint8_t PeekParasiteTube4(void *tube, M6502Word a);
+uint8_t PeekParasiteTube5(void *tube, M6502Word a);
+uint8_t PeekParasiteTube6(void *tube, M6502Word a);
+uint8_t PeekParasiteTube7(void *tube, M6502Word a);
 void WriteParasiteTube1(void *tube, M6502Word a, uint8_t value);
 void WriteParasiteTube3(void *tube, M6502Word a, uint8_t value);
 void WriteParasiteTube5(void *tube, M6502Word a, uint8_t value);

--- a/src/beeb/src/BBCMicro.cpp
+++ b/src/beeb/src/BBCMicro.cpp
@@ -2486,6 +2486,15 @@ void BBCMicro::InitStuff() {
         m_parasite_read_mmio_fns[6] = &ReadParasiteTube6;
         m_parasite_read_mmio_fns[7] = &ReadParasiteTube7;
 
+        m_parasite_peek_mmio_fns[0] = &PeekParasiteTube0;
+        m_parasite_peek_mmio_fns[1] = &PeekParasiteTube1;
+        m_parasite_peek_mmio_fns[2] = &PeekParasiteTube2;
+        m_parasite_peek_mmio_fns[3] = &PeekParasiteTube3;
+        m_parasite_peek_mmio_fns[4] = &PeekParasiteTube4;
+        m_parasite_peek_mmio_fns[5] = &PeekParasiteTube5;
+        m_parasite_peek_mmio_fns[6] = &PeekParasiteTube6;
+        m_parasite_peek_mmio_fns[7] = &PeekParasiteTube7;
+
         m_parasite_write_mmio_fns[0] = &WriteTubeDummy;
         m_parasite_write_mmio_fns[1] = &WriteParasiteTube1;
         m_parasite_write_mmio_fns[2] = &WriteTubeDummy;

--- a/src/beeb/src/BBCMicro_Update.inl
+++ b/src/beeb/src/BBCMicro_Update.inl
@@ -140,7 +140,11 @@ uint32_t BBCMicro::UpdateTemplated(VideoDataUnit *video_unit, SoundDataUnit *sou
 
         if (m_state.parasite_cpu.read) {
             if ((m_state.parasite_cpu.abus.w & 0xfff0) == 0xfef0) {
-                m_state.parasite_cpu.dbus = (*m_parasite_read_mmio_fns[m_state.parasite_cpu.abus.w & 7])(&m_state.parasite_tube, m_state.parasite_cpu.abus);
+                if (m_state.parasite_cpu.read == M6502ReadType_Uninteresting) {
+                    m_state.parasite_cpu.dbus = (*m_parasite_peek_mmio_fns[m_state.parasite_cpu.abus.w & 7])(&m_state.parasite_tube, m_state.parasite_cpu.abus);
+                } else {
+                    m_state.parasite_cpu.dbus = (*m_parasite_read_mmio_fns[m_state.parasite_cpu.abus.w & 7])(&m_state.parasite_tube, m_state.parasite_cpu.abus);
+                }
 
                 // This bit is a bit careless about checking for the `Trace`
                 // flag, but that's only an efficiency issue, not important for

--- a/src/beeb/src/tube.cpp
+++ b/src/beeb/src/tube.cpp
@@ -592,3 +592,37 @@ void WriteTubeDummy(void *, M6502Word, uint8_t) {
 
 //////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////
+
+// Side-effect-free peek functions for page-cross fixup cycles.
+// Return the same value as the corresponding Read function but without
+// consuming latch data or updating interrupt flags.
+
+// Status registers are already side-effect-free.
+uint8_t PeekParasiteTube0(void *tube_, M6502Word a) { return ReadParasiteTube0(tube_, a); }
+uint8_t PeekParasiteTube2(void *tube_, M6502Word a) { return ReadParasiteTube2(tube_, a); }
+uint8_t PeekParasiteTube4(void *tube_, M6502Word a) { return ReadParasiteTube4(tube_, a); }
+uint8_t PeekParasiteTube6(void *tube_, M6502Word a) { return ReadParasiteTube6(tube_, a); }
+
+// Data registers: return the value without clearing available flags.
+uint8_t PeekParasiteTube1(void *tube_, M6502Word) {
+    auto t = (Tube *)tube_;
+    return t->h2p1;
+}
+
+uint8_t PeekParasiteTube3(void *tube_, M6502Word) {
+    auto t = (Tube *)tube_;
+    return t->h2p2;
+}
+
+uint8_t PeekParasiteTube5(void *tube_, M6502Word) {
+    auto t = (Tube *)tube_;
+    return t->h2p3[0];
+}
+
+uint8_t PeekParasiteTube7(void *tube_, M6502Word) {
+    auto t = (Tube *)tube_;
+    return t->h2p4;
+}
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Chuckie Egg 2023 – the Tube-based remake by Sam Skivington – didn't load on b2. It got stuck at "Initialising"

<img width="864" height="732" alt="b2-before" src="https://github.com/user-attachments/assets/2e2b3d9b-826b-446b-bdc3-977f64d6a723" />

The 6502's indexed addressing modes perform a read from an intermediate (uncorrected) address during page-cross fixup cycles. When this address falls in the Tube register range ($FEF0-$FEFF), the read has side effects: it consumes latch data and updates interrupt flags, even though the CPU discards the value.

This causes Chuckie Egg 2023 to hang during loading. The game's LZ decompressor uses LDA ($33),Y with a pointer that sweeps through the Tube I/O area. The page-cross fixup read from $FEF9 consumes an R1 byte, shifting the data stream and causing the decompressor to run out of data.

Two changes fix this:

1. The 6502 code generator (6502_gen.cpp) classified page-cross fixup reads as M6502ReadType_Instruction (via the M6502ReadType_Data + acarry trick) instead of M6502ReadType_Uninteresting. Replace the addition with an explicit ternary that produces Uninteresting when acarry is set.

2. The parasite update loop (BBCMicro_Update.inl) now checks the read type and routes Uninteresting reads through side-effect-free peek functions that return the Tube register value without consuming latch data or updating interrupt flags.

I don't know if they way I've fixed it is appropriate for b2, and I'm struggling to defend this fix in terms of how I think the actual hardware must work (Why wouldn't dummy reads clear the Tube latch?) but the net effect is that the game now loads on b2,

<img width="864" height="732" alt="Screenshot 2026-03-19 at 20 45 00" src="https://github.com/user-attachments/assets/e0504440-0181-402f-b9ef-4e745b014788" />

and plays well too!

<img width="864" height="732" alt="Screenshot 2026-03-19 at 20 45 36" src="https://github.com/user-attachments/assets/7f85d8e7-5ce0-4327-852f-d583c66dc33e" />

