### PR TITLE
Fix 65C02 dead cycle bus addresses for indexed addressing modes

### DIFF
--- a/src/6502/6502_gen.cpp
+++ b/src/6502/6502_gen.cpp
@@ -374,8 +374,8 @@ class Instr {
                             // set differently.
                             *ifun += CMOS_FUNCTION_SUFFIX;
                         } else if ((type == InstrType_RMW) ||
-                                   (type == InstrType_W && (m == Mode_Abx || m == Mode_Aby)) ||
-                                   (type == InstrType_R && (m == Mode_Abx || m == Mode_Aby))) {
+                                   (type == InstrType_W && (m == Mode_Abx || m == Mode_Aby || m == Mode_Iny)) ||
+                                   (type == InstrType_R && (m == Mode_Abx || m == Mode_Aby || m == Mode_Iny || m == Mode_Zpx || m == Mode_Zpy || m == Mode_Inx))) {
                             *tfun = CMOS_FUNCTION_SUFFIX;
                         }
                     }

--- a/src/6502/c/6502.c
+++ b/src/6502/c/6502.c
@@ -1248,6 +1248,277 @@ static void Cycle4_R_ABY_CMOS_AC1(M6502 *s) {
 //////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////
 
+// 65C02 zpg,X/Y: dead cycle reads PBA instead of PFA.
+// The NMOS version reads the unindexed ZP address; the 65C02 re-reads
+// the previous bus address (the operand fetch address).
+//
+// Reference: "6502 Dead Cycles" Row 1.
+
+static void Cycle1_R_ZPX_CMOS(M6502 *);
+static void Cycle2_R_ZPX_CMOS(M6502 *);
+static void Cycle3_R_ZPX_CMOS(M6502 *);
+
+static void Cycle0_R_ZPX_CMOS(M6502 *s) {
+    s->abus.w = s->pc.w++;
+    s->read = M6502ReadType_Instruction;
+    s->tfn = &Cycle1_R_ZPX_CMOS;
+}
+
+static void Cycle1_R_ZPX_CMOS(M6502 *s) {
+    s->ad.b.l = s->dbus;
+    /* PBA: leave abus unchanged (still the operand address from Cycle0) */
+    s->read = M6502ReadType_Uninteresting;
+    s->tfn = &Cycle2_R_ZPX_CMOS;
+}
+
+static void Cycle2_R_ZPX_CMOS(M6502 *s) {
+    s->abus.b.l = s->ad.b.l + s->x;
+    s->abus.b.h = 0;
+    s->read = M6502ReadType_Data;
+    s->tfn = &Cycle3_R_ZPX_CMOS;
+    CheckForInterrupts(s);
+}
+
+static void Cycle3_R_ZPX_CMOS(M6502 *s) {
+    s->data = s->dbus;
+    (*s->ifn)(s);
+#ifdef _DEBUG
+    s->ifn = NULL;
+#endif
+    M6502_NextInstruction(s);
+}
+
+/* 65C02 zpg,Y variant (same structure, different index register) */
+
+static void Cycle1_R_ZPY_CMOS(M6502 *);
+static void Cycle2_R_ZPY_CMOS(M6502 *);
+static void Cycle3_R_ZPY_CMOS(M6502 *);
+
+static void Cycle0_R_ZPY_CMOS(M6502 *s) {
+    s->abus.w = s->pc.w++;
+    s->read = M6502ReadType_Instruction;
+    s->tfn = &Cycle1_R_ZPY_CMOS;
+}
+
+static void Cycle1_R_ZPY_CMOS(M6502 *s) {
+    s->ad.b.l = s->dbus;
+    /* PBA: leave abus unchanged */
+    s->read = M6502ReadType_Uninteresting;
+    s->tfn = &Cycle2_R_ZPY_CMOS;
+}
+
+static void Cycle2_R_ZPY_CMOS(M6502 *s) {
+    s->abus.b.l = s->ad.b.l + s->y;
+    s->abus.b.h = 0;
+    s->read = M6502ReadType_Data;
+    s->tfn = &Cycle3_R_ZPY_CMOS;
+    CheckForInterrupts(s);
+}
+
+static void Cycle3_R_ZPY_CMOS(M6502 *s) {
+    s->data = s->dbus;
+    (*s->ifn)(s);
+#ifdef _DEBUG
+    s->ifn = NULL;
+#endif
+    M6502_NextInstruction(s);
+}
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+// 65C02 (zpg),Y: dead cycle reads PBA instead of PFA on page cross.
+//
+// Reference: "6502 Dead Cycles" Row 5 (read), Row 7 (write).
+
+static void Cycle1_R_INY_CMOS(M6502 *);
+static void Cycle2_R_INY_CMOS(M6502 *);
+static void Cycle3_R_INY_CMOS(M6502 *);
+static void Cycle4_R_INY_CMOS_AC0(M6502 *);
+static void Cycle4_R_INY_CMOS_AC1(M6502 *);
+static void Cycle5_R_INY_CMOS_AC1(M6502 *);
+
+static void Cycle0_R_INY_CMOS(M6502 *s) {
+    s->abus.w = s->pc.w++;
+    s->read = M6502ReadType_Instruction;
+    s->tfn = &Cycle1_R_INY_CMOS;
+}
+
+static void Cycle1_R_INY_CMOS(M6502 *s) {
+    s->ia.b.l = s->dbus;
+    s->abus.w = s->ia.b.l;
+    s->read = M6502ReadType_Address;
+    s->tfn = &Cycle2_R_INY_CMOS;
+}
+
+static void Cycle2_R_INY_CMOS(M6502 *s) {
+    s->ad.b.l = s->dbus;
+    s->abus.w = (uint8_t)(s->ia.b.l + 1);
+    s->read = M6502ReadType_Address;
+    s->tfn = &Cycle3_R_INY_CMOS;
+}
+
+static void Cycle3_R_INY_CMOS(M6502 *s) {
+    s->ad.b.h = s->dbus;
+    M6502Word ffa = {s->ad.w + s->y};
+    if (ffa.b.h != s->ad.b.h) {
+        /* Page cross: PBA (leave abus unchanged from Cycle2) */
+        s->read = M6502ReadType_Uninteresting;
+        s->tfn = &Cycle4_R_INY_CMOS_AC1;
+    } else {
+        /* No page cross: read from effective address */
+        CheckForInterrupts(s);
+        s->abus = ffa;
+        s->read = M6502ReadType_Data;
+        s->tfn = &Cycle4_R_INY_CMOS_AC0;
+    }
+}
+
+static void Cycle4_R_INY_CMOS_AC0(M6502 *s) {
+    s->data = s->dbus;
+    (*s->ifn)(s);
+#ifdef _DEBUG
+    s->ifn = NULL;
+#endif
+    M6502_NextInstruction(s);
+}
+
+static void Cycle4_R_INY_CMOS_AC1(M6502 *s) {
+    s->abus.w = s->ad.w + s->y;
+    CheckForInterrupts(s);
+    s->read = M6502ReadType_Data;
+    s->tfn = &Cycle5_R_INY_CMOS_AC1;
+}
+
+static void Cycle5_R_INY_CMOS_AC1(M6502 *s) {
+    s->data = s->dbus;
+    (*s->ifn)(s);
+#ifdef _DEBUG
+    s->ifn = NULL;
+#endif
+    M6502_NextInstruction(s);
+}
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+// 65C02 STA (zpg),Y: dead cycle reads PBA on page cross, FFA otherwise.
+//
+// Reference: "6502 Dead Cycles" Row 6 (no cross), Row 7 (cross).
+
+static void Cycle1_W_INY_CMOS(M6502 *);
+static void Cycle2_W_INY_CMOS(M6502 *);
+static void Cycle3_W_INY_CMOS(M6502 *);
+static void Cycle4_W_INY_CMOS(M6502 *);
+static void Cycle5_W_INY_CMOS(M6502 *);
+
+static void Cycle0_W_INY_CMOS(M6502 *s) {
+    s->abus.w = s->pc.w++;
+    s->read = M6502ReadType_Instruction;
+    s->tfn = &Cycle1_W_INY_CMOS;
+}
+
+static void Cycle1_W_INY_CMOS(M6502 *s) {
+    s->ia.b.l = s->dbus;
+    s->abus.w = s->ia.b.l;
+    s->read = M6502ReadType_Address;
+    s->tfn = &Cycle2_W_INY_CMOS;
+}
+
+static void Cycle2_W_INY_CMOS(M6502 *s) {
+    s->ad.b.l = s->dbus;
+    s->abus.w = (uint8_t)(s->ia.b.l + 1);
+    s->read = M6502ReadType_Address;
+    s->tfn = &Cycle3_W_INY_CMOS;
+}
+
+static void Cycle3_W_INY_CMOS(M6502 *s) {
+    s->ad.b.h = s->dbus;
+    M6502Word ffa = {s->ad.w + s->y};
+    if (ffa.b.h != s->ad.b.h) {
+        /* Page cross: PBA (leave abus unchanged from Cycle2) */
+        s->read = M6502ReadType_Uninteresting;
+    } else {
+        /* No page cross: FFA on bus */
+        s->abus.w = s->ad.b.l + s->y;
+        s->abus.b.h = s->ad.b.h;
+        s->read = M6502ReadType_Uninteresting;
+    }
+    s->tfn = &Cycle4_W_INY_CMOS;
+}
+
+static void Cycle4_W_INY_CMOS(M6502 *s) {
+    s->abus.w = s->ad.w + s->y;
+    (*s->ifn)(s);
+    s->read = 0;
+    s->dbus = s->data;
+    s->tfn = &Cycle5_W_INY_CMOS;
+    CheckForInterrupts(s);
+}
+
+static void Cycle5_W_INY_CMOS(M6502 *s) {
+    M6502_NextInstruction(s);
+}
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+// 65C02 (zpg,X): dead cycle reads PBA instead of PFA.
+//
+// Reference: "6502 Dead Cycles" Row 8.
+
+static void Cycle1_R_INX_CMOS(M6502 *);
+static void Cycle2_R_INX_CMOS(M6502 *);
+static void Cycle3_R_INX_CMOS(M6502 *);
+static void Cycle4_R_INX_CMOS(M6502 *);
+static void Cycle5_R_INX_CMOS(M6502 *);
+
+static void Cycle0_R_INX_CMOS(M6502 *s) {
+    s->abus.w = s->pc.w++;
+    s->read = M6502ReadType_Instruction;
+    s->tfn = &Cycle1_R_INX_CMOS;
+}
+
+static void Cycle1_R_INX_CMOS(M6502 *s) {
+    s->ia.b.l = s->dbus;
+    /* PBA: leave abus unchanged (still the operand address from Cycle0) */
+    s->read = M6502ReadType_Uninteresting;
+    s->tfn = &Cycle2_R_INX_CMOS;
+}
+
+static void Cycle2_R_INX_CMOS(M6502 *s) {
+    s->abus.w = (uint8_t)(s->ia.b.l + s->x);
+    s->read = M6502ReadType_Address;
+    s->tfn = &Cycle3_R_INX_CMOS;
+}
+
+static void Cycle3_R_INX_CMOS(M6502 *s) {
+    s->ad.b.l = s->dbus;
+    s->abus.w = (uint8_t)(s->ia.b.l + s->x + 1);
+    s->read = M6502ReadType_Address;
+    s->tfn = &Cycle4_R_INX_CMOS;
+}
+
+static void Cycle4_R_INX_CMOS(M6502 *s) {
+    s->ad.b.h = s->dbus;
+    s->abus = s->ad;
+    s->read = M6502ReadType_Data;
+    s->tfn = &Cycle5_R_INX_CMOS;
+    CheckForInterrupts(s);
+}
+
+static void Cycle5_R_INX_CMOS(M6502 *s) {
+    s->data = s->dbus;
+    (*s->ifn)(s);
+#ifdef _DEBUG
+    s->ifn = NULL;
+#endif
+    M6502_NextInstruction(s);
+}
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
 static void Cycle1_RMW_ABX_CMOS(M6502 *s);
 static void Cycle2_RMW_ABX_CMOS(M6502 *s);
 static void Cycle3_RMW_ABX_CMOS(M6502 *s);


### PR DESCRIPTION
The 65C02 re-reads the Previous Bus Address (PBA) during dead cycles, instead of putting the Partially Formed Address (PFA) on the bus as the NMOS 6502 does.

This was discovered during development of #569, though the approach there is more of a workaround than a proper solution.

This difference between NMOS 6502 and 65C02 is documented in "6502 Dead Cycles, V1.1" by Drass and Dr Jefyll and referenced in #570. 

  https://github.com/bitshifters/bbc-documents/blob/master/ICs/6502%20CPU/6502%20Dead%20Cycles.pdf

Several addressing modes were sharing NMOS-generated cycle functions on 65C02 configs, causing PFA to appear on the bus during dead cycles instead of PBA. This is the root cause of the Chuckie Egg 2023 Tube hang (#569): the PFA sweeps through Tube register addresses during a page-cross fixup cycle, consuming an R1 latch byte.

Add hand-written CMOS cycle functions for five addressing modes:

- R_ZPX_CMOS / R_ZPY_CMOS (Row 1: zpg,X / zpg,Y reads)
- R_INY_CMOS (Row 5: (zpg),Y reads)
- W_INY_CMOS (Row 6-7: (zpg),Y writes)
- R_INX_CMOS (Row 8: (zpg,X) reads)

Each variant leaves abus unchanged during the dead cycle (retaining PBA from the previous bus access) instead of computing the partially formed address. This matches the existing pattern used by R_ABX_CMOS and R_ABY_CMOS.

Update the code generator to dispatch these modes to CMOS variants on 65C02 configs.

This supersedes the read-type workaround from #569. With correct bus addresses, dead cycles no longer hit I/O device addresses, so no filtering is needed.

See #570.